### PR TITLE
Change local path on android after scoped storage

### DIFF
--- a/src/fieldwork/data_sync.md
+++ b/src/fieldwork/data_sync.md
@@ -14,7 +14,7 @@ You can also drag-and-drop your project folder (including layers, SVGs, etc) to 
 
 ## Manual data transfer (Android)
 
-This can be done by connecting your mobile device to the computer and copying data files to/from the device. Once your Android phone or tablet is recognized by the operating system after connecting it using USB cable, you can use file browser to copy files. On Android devices, data are stored in `INPUT/projects` directory.
+This can be done by connecting your mobile device to the computer and copying data files to/from the device. Once your Android phone or tablet is recognized by the operating system after connecting it using USB cable, you can use file browser to copy files. On Android devices, data are stored in `Internal storage/Android/data/uk.co.lutraconsulting/files/projects` directory.
 
 ## Manual data transfer (iOS)
 
@@ -22,7 +22,7 @@ Input supports iTunes file sharing. Note that iTunes doesn't allow you to browse
 
 * Plug iOS device to a computer
 * Open `Finder` file browser
-* Go to Locations -> `<device_name>` 
+* Go to Locations -> `<device_name>`
 ![iTunes](./itunes.png)
 * Click on the tab named `files`  
 * Select `Input` app from a list to see a data folder


### PR DESCRIPTION
Change path in docs where user can access local projects. Path changed due to a scoped storage update.