### PR TITLE
fix #34 added plugin installation instructions

### DIFF
--- a/src/tutorials/creating-a-project-in-qgis/index.md
+++ b/src/tutorials/creating-a-project-in-qgis/index.md
@@ -4,14 +4,13 @@
 
 In earlier tutorials you created a new survey project from within <MobileAppName />. That was a very fast (albeit limited) way of creating a <MainPlatformName /> project.
 
-In this tutorial you will create a new project using QGIS, a free and open source desktop GIS package. <MobileAppName /> is based on QGIS which means it's able to visualise and edit data in the same way QGIS can. This offers us great flexibility which we'll start to see in a moment.
-
-In this tutorial we will set up a project for surveying trees and hedges.  
+In this tutorial you will create a new project for surveying trees and hedges using QGIS.  
 
 ## Before we start
 
 Please ensure you have already:
-
+* [Installed QGIS](../../howto/install-qgis/index.md)
+* [Signed up to <MainPlatformName />](../../howto/sign-up-to-mergin-maps/index.md)
 * [Installed the <QGISPluginName />](../../howto/install-mergin-maps-plugin-for-qgis/index.md)
 
 

--- a/src/tutorials/opening-surveyed-data-on-your-computer/index.md
+++ b/src/tutorials/opening-surveyed-data-on-your-computer/index.md
@@ -2,11 +2,15 @@
 
 [[toc]]
 
-In the last tutorial you learnt how to FIXME.
+In the last tutorial you learnt how to capture field data using <MobileAppName />.
 
-In this tutorial you'll learn how to:
+In this tutorial you'll learn how to transfer data from mobile device to computer in seconds using QGIS, a free and open source desktop GIS package. <MobileAppName /> is based on QGIS, which means it's able to visualise and edit data in the same way QGIS can. This offers us great flexibility which we'll start to see in a moment.
 
-* Transfer data from mobile device to computer in seconds
+
+## Before we start
+
+Please ensure you have already:
+* [Installed QGIS](../../howto/install-qgis/index.md)
 
 
 ## Putting your project in the cloud
@@ -42,7 +46,10 @@ In this tutorial you'll learn how to:
 
 1. Open QGIS on your computer
 
-2. Find the Mergin entry in the QGIS browser panel:
+2. [Install the <QGISPluginName />](../../howto/install-mergin-maps-plugin-for-qgis/index.md)
+   You will use your <MainPlatformName /> credentials to configure the <QGISPluginName />.
+
+3. Find the Mergin entry in the QGIS browser panel:
 
    ![](./qgis-browser-panel.jpg)
    
@@ -50,15 +57,15 @@ In this tutorial you'll learn how to:
    If you cannot see the browser panel in QGIS, ensure it's enabled under ***View (top-level menu) > Toolbars***.
    :::
    
-3. Expand the Mergin entry and find your project under ***My projects***
+4. Expand the Mergin entry and find your project under ***My projects***
 
    ![](./qgis-find-project.jpg)
 
-4. Right-click on the project and select ***Download***
+5. Right-click on the project and select ***Download***
 
    ![](./qgis-download-project.jpg)
 
-5. Select a folder under which your project will be stored locally
+6. Select a folder under which your project will be stored locally
 
    Select a folder called ***Mergin Projects*** under ***My Documents***, creating it if it doesn't already exist.
 
@@ -70,14 +77,13 @@ In this tutorial you'll learn how to:
    
    ![](./qgis-downloading-project.jpg)
 
-6. Open the project when prompted:
+7. Open the project when prompted:
 
    ![](./qgis-open-project-file.jpg)
    
    Your first survey project is now open in QGIS:
    
    ![](./qgis-project-opened.jpg)
-
 
 
 ## Extracting data from QGIS


### PR DESCRIPTION
- short intro about QGIS was moved to https://merginmaps.com/docs/tutorials/opening-surveyed-data-on-your-computer/ from the following tutorial https://merginmaps.com/docs/tutorials/creating-a-project-in-qgis/
- added "before we start" section
- added plugin installation step to "Locating and opening your project"
