### PR TITLE
fix #173 cloudmergin to merginmaps.com

### DIFF
--- a/scripts/wordlist.txt
+++ b/scripts/wordlist.txt
@@ -67,6 +67,7 @@ MSI
 MVT
 Mercedes
 Mergin
+merginmaps
 Multiline
 NDK
 OneDrive

--- a/src/.vuepress/components/AppDomainNameLink.vue
+++ b/src/.vuepress/components/AppDomainNameLink.vue
@@ -1,0 +1,19 @@
+<template>
+  <a :href="`https://app.merginmaps.com/${id}`" target="_blank" class="nospellcheck">
+    <span v-if="desc" v-html="desc"></span>
+    <span v-else class="nospellcheck">app.merginmaps.com</span>
+  </a>
+</template>
+
+<script>
+export default {
+  name: "AppDomainNameLink",
+  props: {
+    id: {
+      type: String,
+      default: ''
+    },
+    desc: String
+  }
+}
+</script>

--- a/src/.vuepress/components/MainDomainName.vue
+++ b/src/.vuepress/components/MainDomainName.vue
@@ -1,3 +1,3 @@
 <template>
-  <span class="nospellcheck">cloudmergin.com</span>
+  <span class="nospellcheck">merginmaps.com</span>
 </template>

--- a/src/.vuepress/components/MainDomainNameLink.vue
+++ b/src/.vuepress/components/MainDomainNameLink.vue
@@ -1,7 +1,7 @@
 <template>
-  <a :href="`https://public.cloudmergin.com/${id}`" target="_blank" class="nospellcheck">
+  <a :href="`https://merginmaps.com/${id}`" target="_blank" class="nospellcheck">
     <span v-if="desc" v-html="desc"></span>
-    <span v-else class="nospellcheck">cloudmergin.com</span>
+    <span v-else class="nospellcheck">merginmaps.com</span>
   </a>
 </template>
 

--- a/src/.vuepress/components/MerginMapsProject.vue
+++ b/src/.vuepress/components/MerginMapsProject.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <a :href="`https://public.cloudmergin.com/projects/${id}/tree`" target="_blank" rel="noopener noreferrer">
+    <a :href="`https://app.merginmaps.com/projects/${id}/tree`" target="_blank" rel="noopener noreferrer">
       <img :alt="`Mergin Maps Project ${id}`" :src="$withBase('/mm_icon_positive_no_padding.svg')" />
       <span v-html="id" class="nospellcheck"></span>
       <span>

--- a/src/.vuepress/components/MerginMapsProjectShort.vue
+++ b/src/.vuepress/components/MerginMapsProjectShort.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <a :href="`https://public.cloudmergin.com/projects/${id}/tree`" target="_blank" rel="noopener noreferrer">
+    <a :href="`https://app.merginmaps.com/projects/${id}/tree`" target="_blank" rel="noopener noreferrer">
       <img :alt="`Mergin Maps Project ${id}`" :src="$withBase('/mm_logo_positive_no_padding.svg')" />
        <span>
         <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" x="0px" y="0px" viewBox="0 0 100 100" width="15" height="15" class="icon outbound">

--- a/src/dev/customapp.md
+++ b/src/dev/customapp.md
@@ -8,4 +8,4 @@ The good news is that <MobileAppName /> is licensed as open source software and 
 
 If you are interested in building a custom app, you can start by going to <GitHubRepo id="lutraconsulting/input" desc="Mergin Maps Input repository" /> on GitHub and building it for your platform. The <GitHubRepo id="lutraconsulting/input-sdk" desc="Input SDK repository" /> provides all the dependencies for various platforms (Android, iOS, macOS, Windows).
 
-For the Input source code and developers' documentation, you can visit <GitHubRepo id="lutraconsulting/input" />.
+For the <MobileAppName /> source code and developers' documentation, you can visit <GitHubRepo id="lutraconsulting/input" />.

--- a/src/dev/integration.md
+++ b/src/dev/integration.md
@@ -56,7 +56,7 @@ Options:
   --version   Show the version information.
   --username  Mergin username (or MERGIN_USERNAME env. variable)
   --password  Mergin password (or MERGIN_PASSWORD env. variable)
-  --url       Mergin url      (defaults to public.cloudmergin.com)
+  --url       Mergin url      (defaults to app.merginmaps.com)
 
 Commands:
   create         Create a new project on Mergin server
@@ -69,4 +69,4 @@ Please see <GitHubRepo id="lutraconsulting/mergin-cpp-client" /> repository for 
 
 ### C++ Mergin API core library 
 
-Client is based on the Qt-based <GitHubRepo id="lutraconsulting/input/tree/master/core" desc="mergin api core library" /> used by the [Mergin Maps Input](https://inputapp.io) to sync the projects in the mobile application.
+Client is based on the Qt-based <GitHubRepo id="lutraconsulting/input/tree/master/core" desc="mergin api core library" /> used by the <MainDomainNameLink desc="Mergin Maps Input" /> to sync the projects in the mobile application.

--- a/src/dev/mergince.md
+++ b/src/dev/mergince.md
@@ -1,6 +1,6 @@
 # Mergin Community Edition
 
-The [Mergin](https://public.cloudmergin.com) is a great companion to <MobileAppName /> as it provides seamless synchronisation of data between your phone/tablet, Mergin service and QGIS Desktop.
+The [Mergin](https://merginmaps.com/) is a great companion to <MobileAppName /> as it provides seamless synchronisation of data between your phone/tablet, Mergin service and QGIS Desktop.
 
 The good news is that Mergin CE is licensed as open source software and therefore it is possible to do your custom deployments.
 

--- a/src/field/input_ui.md
+++ b/src/field/input_ui.md
@@ -28,7 +28,7 @@ Tapping the GPS button centres the map to your current position.
 
 Pressing and holding the GPS button turns on / turns off the GPS auto-centre mode.
 
-GPS signal colour on the map denotes the accuracy threshold set by the user within the Input in [GPS settings](#gps-settings). GPS accuracy is displayed at the bottom of the map. 
+GPS signal colour on the map denotes the accuracy threshold set by the user within the <MobileAppName /> in [GPS settings](#gps-settings). GPS accuracy is displayed at the bottom of the map. 
 
 ![GPS](./input-gps.png) 
 

--- a/src/field/reuse-last-values/index.md
+++ b/src/field/reuse-last-values/index.md
@@ -25,6 +25,6 @@ To allow this functionality, follow these steps:
 
 ![photos](./reuse_last_values_digitize_after.png)
 
-You can use the `Reuse last value option` across multiple layers. Input will remember attributes for each layer separately.
+You can use the `Reuse last value option` across multiple layers. <MobileAppName /> will remember attributes for each layer separately.
 
 This feature was inspired by QGIS functionality called _Reuse last entered attribute values_.

--- a/src/field/stake-out/index.md
+++ b/src/field/stake-out/index.md
@@ -1,7 +1,7 @@
 # How to Stake Out Points
 <Badge text="since Input 1.3.0" type="tip"/>
 
-Points in your survey layers can be staked out. Input will navigate you towards the selected point showing you the direction and distance.
+Points in your survey layers can be staked out. <MobileAppName /> will navigate you towards the selected point showing you the direction and distance.
 
 There are two stake out modes:
 - long navigation mode

--- a/src/gis/features.md
+++ b/src/gis/features.md
@@ -38,7 +38,7 @@ During the field survey, it is often necessary to fill out some attributes in th
 ### Settings for Mergin Maps Input preview panel
 What appears in the <MobileAppName /> preview panel can be defined in the **Display** tab in **Layer Properties**:
 - **Display Name**: a field name or an expression.
-- **HTML Map Tip**: the content of the preview panel. While QGIS always interprets the content of map tip as being HTML, <MobileAppName /> extends the syntax to allow two more modes: field values and images. If the map tip is not specified, Input will try to use the first three fields and show their attribute values.
+- **HTML Map Tip**: the content of the preview panel. While QGIS always interprets the content of map tip as being HTML, <MobileAppName /> extends the syntax to allow two more modes: field values and images. If the map tip is not specified, <MobileAppName /> will try to use the first three fields and show their attribute values.
 
 ![Display setting in QGIS](./qgis_properties_display.png)
 

--- a/src/gis/proj.md
+++ b/src/gis/proj.md
@@ -2,11 +2,11 @@
 
 <Badge text="Since Input 0.8.0" type="info"/>
 
-You can read more about Map Projections and Coordinate Reference Systems in this [extended article](./projections/index.md)
+You can read more about Map Projections and Coordinate Reference Systems in this [extended article](./projections/index.md).
 
 ## Using custom PROJ
 
-When Input is launched, it searches for `<project folder>/proj` for custom PROJ datum shifts files in all available projects on the disk. These shift files can be then used in all projects for custom PROJ datum shift.
+When <MobileAppName /> is launched, it searches for `<project folder>/proj` for custom PROJ datum shifts files in all available projects on the disk. These shift files can be then used in all projects for custom PROJ datum shift.
 
 If you want to use your custom PROJ datum shifts, copy them to the folder `<project folder>/proj` to correctly render your QGIS project on <MobileAppName />. Note that one the project is firstly downloaded to <MobileAppName />, you have to restart <MobileAppName /> to load your custom datum shifts.
 

--- a/src/gis/projections/index.md
+++ b/src/gis/projections/index.md
@@ -35,7 +35,7 @@ Your QGIS installation contains the basic set of PROJ resources required for mos
 
 ## Example capture GPS point for Great Britain  
 
-For example, imagine we have a project for the Great Britain, where we use map projection British National Grid (EPSG:27700) to display map. We have background map in the same coordinate reference system, so there is no datum transformation required to show it. However we want to capture point by GPS receiver in the field by [Mergin Maps Input](https://inputapp.io), and we add a point layer in WGS 84 coordinate reference system. When we add point to this point layer, we store the coordinate values (latitude and longitude received from GPS) as is in the data section of our layer. When we want to show the point on the QGIS map canvas, QGIS needs to first do datum transformation, following by map projection.
+For example, imagine we have a project for the Great Britain, where we use map projection British National Grid (EPSG:27700) to display map. We have background map in the same coordinate reference system, so there is no datum transformation required to show it. However we want to capture point by GPS receiver in the field by <MobileAppName />, and we add a point layer in WGS 84 coordinate reference system. When we add point to this point layer, we store the coordinate values (latitude and longitude received from GPS) as is in the data section of our layer. When we want to show the point on the QGIS map canvas, QGIS needs to first do datum transformation, following by map projection.
 
 ![projection transformation](./projection_transformation.png)
 
@@ -49,7 +49,7 @@ In this case, the recommended transform is the[OSTN15 transformation](https://ww
 
 ### 2. Map projection
 
-Once the data is in the same datum, they are projected to 2d flat space (map canvas) and rendered to the user in QGIS or [Mergin Maps Input](https://inputapp.io).
+Once the data is in the same datum, they are projected to 2d flat space (map canvas) and rendered to the user in QGIS or <MobileAppName />.
 
 ## What could possibly go wrong?
 

--- a/src/gis/settingup_background_map.md
+++ b/src/gis/settingup_background_map.md
@@ -1,9 +1,9 @@
 # Background Maps
 [[toc]]
 
-When surveying in the field, it is essential to have appropriate background maps. There are several sources of online and offline background maps you can use in your QGIS project. Note that you need to comply with the terms of use of the background maps and their data sources. This page simply explains how to add the data to your QGIS maps and use it in Input. It will be the sole responsibility of the end user to comply with such terms and conditions.
+When surveying in the field, it is essential to have appropriate background maps. There are several sources of online and offline background maps you can use in your QGIS project. Note that you need to comply with the terms of use of the background maps and their data sources. This page simply explains how to add the data to your QGIS maps and use it in <MobileAppName />. It will be the sole responsibility of the end user to comply with such terms and conditions.
 
-The following sections will cover two types of background maps for online and offline use in Input:
+The following sections will cover two types of background maps for online and offline use in <MobileAppName />:
 
 ## Raster tiles 
 

--- a/src/gis/setup_themes.md
+++ b/src/gis/setup_themes.md
@@ -1,6 +1,6 @@
 # Map Themes
 
-In Input, you can use different **map themes**. This is ideal for switching between different background maps (e.g. cartography map and aerial photography). The map themes should be first set up in QGIS.
+In <MobileAppName />, you can use different **map themes**. This is ideal for switching between different background maps (e.g. cartography map and aerial photography). The map themes should be first set up in QGIS.
 
 # Setting up QGIS map themes
 
@@ -12,7 +12,7 @@ Read how to <QGISHelp ver="3.22" link="user_manual/introduction/general_tools.ht
 - Add new themes or replace existing themes.
 
 # Map themes in Mergin Maps Input
-To access the Map Themes in Input, select **More** > **Map themes**. The list of the Map Themes should appear as a pop up.
+To access the Map Themes, select **More** > **Map themes**. The list of the Map Themes should appear as a pop up.
 
 ![Map Themes](./input_map_themes_osm.png)
 ![Map Themes](./input_map_themes_base.png)

--- a/src/index.md
+++ b/src/index.md
@@ -15,8 +15,8 @@ home: false
 The ecosystem consist of various components:
  - [QGIS](https://qgis.org/) > Powerful GIS Desktop application 
  - [QGIS Mergin Plugin](https://plugins.qgis.org/plugins/Mergin/) > <QGISPluginName />
- - [Mergin Cloud](https://merginmaps.com) > SaaS Cloud Service (available also as Mergin CE)
- - [Mergin Maps Input](https://inputapp.io) > the <MobileAppName /> for iOS and Android
+ - <MainDomainNameLink desc="Mergin Maps Cloud" /> > SaaS Cloud Service (available also as Mergin CE)
+ - <MainDomainNameLink desc="Mergin Maps Input" /> > the <MobileAppName /> for iOS and Android
  
 ## Get started 
 

--- a/src/index.md
+++ b/src/index.md
@@ -15,7 +15,7 @@ home: false
 The ecosystem consist of various components:
  - [QGIS](https://qgis.org/) > Powerful GIS Desktop application 
  - [QGIS Mergin Plugin](https://plugins.qgis.org/plugins/Mergin/) > <QGISPluginName />
- - [Mergin Cloud](https://public.cloudmergin.com) > SaaS Cloud Service (available also as Mergin CE)
+ - [Mergin Cloud](https://merginmaps.com) > SaaS Cloud Service (available also as Mergin CE)
  - [Mergin Maps Input](https://inputapp.io) > the <MobileAppName /> for iOS and Android
  
 ## Get started 

--- a/src/layer/attach-multiple-photos-to-features/index.md
+++ b/src/layer/attach-multiple-photos-to-features/index.md
@@ -20,6 +20,6 @@ To create 1:N relation between these tables correctly, you need to:
 3. Create a new text field in the non-spatial table that will be used to store the UUID of features from the survey layer (the foreign key).
 4. Configure 1:N relation in the QGIS project:
 
-Input detects the type of 1-N relation and uses the [Attachment widget](../settingup_forms_photo.md) to display the image viewer for the relations. 
+<MobileAppName /> detects the type of 1-N relation and uses the [Attachment widget](../settingup_forms_photo.md) to display the image viewer for the relations. 
 
 ![Many photos to a single feature](./input_forms_many-photos.png)

--- a/src/layer/attach-multiple-photos-to-features/index.md
+++ b/src/layer/attach-multiple-photos-to-features/index.md
@@ -20,6 +20,6 @@ To create 1:N relation between these tables correctly, you need to:
 3. Create a new text field in the non-spatial table that will be used to store the UUID of features from the survey layer (the foreign key).
 4. Configure 1:N relation in the QGIS project:
 
-<MobileAppName /> detects the type of 1-N relation and uses the [Attachment widget](../settingup_forms_photo.md) to display the image viewer for the relations. 
+Mergin Maps Input detects the type of 1-N relation and uses the [Attachment widget](../settingup_forms_photo.md) to display the image viewer for the relations. 
 
 ![Many photos to a single feature](./input_forms_many-photos.png)

--- a/src/layer/exif_metadata.md
+++ b/src/layer/exif_metadata.md
@@ -1,7 +1,7 @@
 # Exif Metadata
 [[toc]]
 
-Input comes with predefined default value expression functions which can be used to read an image EXIF metadata.
+<MobileAppName /> comes with predefined default value expression functions which can be used to read an image EXIF metadata.
 
 ## Supported functions
 
@@ -28,11 +28,11 @@ Open Settings -> Privacy -> Location Services -> Camera (app).
 ![photos](./ios_geo_tags.png)
 
 ## Use it with photo widget
-The parameter `<ABSOLUTE_PATH_TO_IMAGE>` can be set with an expression using value of another field. Therefore you can use a value from a text field of an attachment type as a parameter for Input's EXIF functions as following:
+The parameter `<ABSOLUTE_PATH_TO_IMAGE>` can be set with an expression using value of another field. Therefore you can use a value from a text field of an attachment type as a parameter for <MobileAppName />'s EXIF functions as following:
 
 `read_exif(@project_home + '/' + "photo", 'GPSImgDirection')`
 
-You can use both `Take a photo` or `From gallery` actions of the attachment widget. While capturing a photo with a camera, GPS EXIF data are added to the photo metadata. Make sure that location permissions are allowed in Input and also for your camera app.
+You can use both `Take a photo` or `From gallery` actions of the attachment widget. While capturing a photo with a camera, GPS EXIF data are added to the photo metadata. Make sure that location permissions are allowed in <MobileAppName /> and also for your camera app.
 
 For further examples you can check fields definitions of project <MerginMapsProject id="lutraconsulting/test_exif" /> accessible on Mergin.
 

--- a/src/layer/plugin-variables.md
+++ b/src/layer/plugin-variables.md
@@ -4,11 +4,11 @@ The plugin adds several variables that can be used in QGIS expressions:
 
 | Variable name               | Sample value                     | Scope   | Description |
 |-----------------------------|----------------------------------|---------|-------------|
-| `@mergin_username`          | `martin`                         | global  | Name of the user currently logged in to Mergin |
-| `@mergin_url`               | `https://public.cloudmergin.com` | global  | URL of the Mergin service |
-| `@mergin_project_name`      | `Tree survey`                    | project | Name of the active Mergin project  |
-| `@mergin_project_owner`     | `martin`                         | project | Name of the owner of the active Mergin project |
+| `@mergin_username`          | `martin`                         | global  | Name of the user currently logged in to <MainPlatformName /> |
+| `@mergin_url`               | `https://app.merginmaps.com` | global  | URL of the <MainPlatformName /> service |
+| `@mergin_project_name`      | `Tree survey`                    | project | Name of the active <MainPlatformName /> project  |
+| `@mergin_project_owner`     | `martin`                         | project | Name of the owner of the active project |
 | `@mergin_project_full_name` | `martin/Tree survey`             | project | Owner and project name joined with a forward slash |
-| `@mergin_project_version`   | `42`                             | project | Current version of the active Mergin project |
+| `@mergin_project_version`   | `42`                             | project | Current version of the active project |
 
 A common use case is to use `@mergin_username` as the default value for one of the fields in a survey layer to automatically track who has added (and/or modified) a particular record.

--- a/src/layer/position_variables.md
+++ b/src/layer/position_variables.md
@@ -1,6 +1,6 @@
 # Extra Position Variables
 
-Input provides the option to access GPS information using an extra position variables. Those can be used as [default values in feature forms](./settingup_forms.md). Note that location permission have to be allowed and location service has to be enabled.
+<MobileAppName /> provides the option to access GPS information using an extra position variables. Those can be used as [default values in feature forms](./settingup_forms.md). Note that location permission have to be allowed and location service has to be enabled.
 
 Following variables are supported:
  - `@position_coordinate` - A point with the coordinates in WGS84.

--- a/src/layer/position_variables.md
+++ b/src/layer/position_variables.md
@@ -1,6 +1,8 @@
 # Extra Position Variables
 
-<MobileAppName /> provides the option to access GPS information using an extra position variables. Those can be used as [default values in feature forms](./settingup_forms.md). Note that location permission have to be allowed and location service has to be enabled.
+<MobileAppName /> provides the option to access GPS information using an extra position variables. Note that location permission have to be allowed and location service has to be enabled.
+
+Extra position variables can be used as [default values in feature forms](./settingup_forms/). 
 
 Following variables are supported:
  - `@position_coordinate` - A point with the coordinates in WGS84.

--- a/src/layer/settingup_forms.md
+++ b/src/layer/settingup_forms.md
@@ -215,7 +215,7 @@ Clone <MerginMapsProject id="documentation/test_forms" /> to follow this example
 The **Value Relation** widget is similar to the [Value Map](#value-map) tool, but the values for the drop-down menu come from another table (e.g. a CSV or another GeoPackage table).
 
 The advantage of having this widget:
-  - Editing the values in the field: for example, if you have missed a value in your list for the drop-down menu, you can edit the table in Input and add the value. See [Working with non-spatial tables](./working_with_nonspatial_data.md) section for more information.
+  - Editing the values in the field: for example, if you have missed a value in your list for the drop-down menu, you can edit the table in <MobileAppName /> and add the value. See [Working with non-spatial tables](./working_with_nonspatial_data.md) section for more information.
   - Searching the values: when you have a large list of values, it will become cumbersome to find the right value. With this widget, you will be able to search for values in the list.
   - Selecting multiple values.
 

--- a/src/layer/working_with_nonspatial_data.md
+++ b/src/layer/working_with_nonspatial_data.md
@@ -14,10 +14,10 @@ Ensure you have enabled editing and searching of your non-spatial table in QGIS.
 
 To browse, search or edit a non-spatial table, first you need to [open the attribute table](../gis/search_data/#searching-for-values-in-mergin-maps-input).
 
-To add a new record, select **Add Feature**. This will open a form to fill. By pressing **Save**, the new record will be added and Input will take you back to the attribute of your table.
+To add a new record, select **Add Feature**. This will open a form to fill. By pressing **Save**, the new record will be added and <MobileAppName /> will take you back to the attribute of your table.
 
 Similar to the vector layer attribute table, you can [search](../gis/search_data.md) your data.
 
-Selecting an individual record, Input will open the form related to the feature.
+Selecting an individual record, <MobileAppName /> will open the form related to the feature.
 
 ![display_name](./input_nonspatial_data.png)

--- a/src/manage/create-project/index.md
+++ b/src/manage/create-project/index.md
@@ -82,7 +82,7 @@ Using <QGISPluginName />, you can make a copy of one of your existing projects o
 
 ## Create a project through merginmaps.com
 
-1. Navigate to <MainDomainNameLink /> and sign in.
+1. Navigate to <AppDomainNameLink /> and sign in.
 
 2. To create a new project, click on **Create** in the **Projects** section:
 

--- a/src/manage/create-project/index.md
+++ b/src/manage/create-project/index.md
@@ -4,9 +4,9 @@
 There are several methods of creating a new <MainPlatformName /> project:
 - [<MobileAppName /> ](./index.md#create-a-project-in-mergin-maps-input) offers the quickest (albeit limited) way of creating a <MainPlatformName /> project.
 - If you want to take full advantage of <MainPlatformName />, use [QGIS](./index.md#create-a-project-in-qgis) to prepare new projects.
-- You can also use [cloudmergin.com](./index.md#create-a-project-through-cloudmergin-com), especially if your project files are already fully prepared and only need uploading.
+- You can also use [merginmaps.com](./index.md#create-a-project-through-merginmaps-com), especially if your project files are already fully prepared and only need uploading.
 
-If you want to make a copy of your projects or the ones shared with you, you can clone them in [QGIS](./index.md#clone-an-existing-project-in-qgis) or [cloudmergin.com](./index.md#clone-an-existing-project-through-cloudmergin-com).
+If you want to make a copy of your projects or the ones shared with you, you can clone them in [QGIS](./index.md#clone-an-existing-project-in-qgis) or [merginmaps.com](./index.md#clone-an-existing-project-through-merginmaps-com).
 
 ## Create a project in Mergin Maps Input
 
@@ -80,7 +80,7 @@ Using <QGISPluginName />, you can make a copy of one of your existing projects o
 
 ![](./clone.png)
 
-## Create a project through cloudmergin.com
+## Create a project through merginmaps.com
 
 1. Navigate to <MainDomainNameLink /> and sign in.
 
@@ -104,7 +104,7 @@ Using <QGISPluginName />, you can make a copy of one of your existing projects o
 
    ![Upload files](./web-project-upload.png)
 
-### Clone an existing project through cloudmergin.com
+### Clone an existing project through merginmaps.com
 
 You can also make a copy of an existing project or a project that is shared with you:
 

--- a/src/manage/missing-data/index.md
+++ b/src/manage/missing-data/index.md
@@ -39,7 +39,7 @@ Manual data transfer from an Android device can be done by connecting your devic
 On Android devices, data are stored in `Internal storage/Android/data/uk.co.lutraconsulting/files/projects` folder.
 
 ### Manual data transfer (between iOS and Mac)
-Input supports iTunes file sharing. Note that iTunes doesn't allow you to browse or edit data from the app data folder, only allows you to delete or copy the data folder to another location. 
+<MobileAppName /> supports iTunes file sharing. Note that iTunes doesn't allow you to browse or edit data from the app data folder, only allows you to delete or copy the data folder to another location. 
 
 You can access your data by following these steps:
 1. Plug iOS device to a computer

--- a/src/manage/plugin-multi-server-use/index.md
+++ b/src/manage/plugin-multi-server-use/index.md
@@ -1,6 +1,6 @@
 # How to Use QGIS Plugin with Multiple Servers
 
-There is a default server <MainDomainNameLink /> which is configured in <QGISPluginName />. But there might be some cases you will want to use some custom server (e.g. you host it yourself). We will cover two typical use cases
+There is a default server <AppDomainNameLink /> which is configured in <QGISPluginName />. But there might be some cases you will want to use some custom server (e.g. you host it yourself). We will cover two typical use cases
 
 - migration from one server to another
 - using multiple servers simultaneously

--- a/src/manage/project-advanced.md
+++ b/src/manage/project-advanced.md
@@ -3,7 +3,7 @@
 
 ## Share a project
 
-Through <MainDomainNameLink />, you can share your project with other Mergin users. You can add your coworkers manually or send them a link and manage their permissions in your private project. You can also make your project accessible to everyone by making it public.
+Through <AppDomainNameLink />, you can share your project with other Mergin users. You can add your coworkers manually or send them a link and manage their permissions in your private project. You can also make your project accessible to everyone by making it public.
 
 ::: tip
 You can follow our [Working collaboratively](../tutorials/working-collaboratively/) tutorial to see detailed instructions on how to share your project.
@@ -28,7 +28,7 @@ Another method which is more suitable for sharing with a large number of users i
 2. Copy the link from your web browser
 3. Share the link with user(s) you want to invite to collaborate
 
-Users can use **Request access** button to request access to your project after logging into <MainDomainNameLink />.
+Users can use **Request access** button to request access to your project after logging into <AppDomainNameLink />.
 
 ![Mergin sharing setting](./project_sharing_send_request.png)
 
@@ -50,7 +50,7 @@ If you change your mind, you can similarly make your project private by clicking
 
 There is an option to transfer the ownership of a project to another user or organisation. 
 
-1. Log in <MainDomainNameLink /> and choose the project you want to transfer
+1. Log in <AppDomainNameLink /> and choose the project you want to transfer
 2. Go to **Settings** and click on **Transfer project**
 3. Enter the name of a user/organisation and **Request transfer**
 4. The user/organisation will be notified to accept or reject the transfer request. The request is valid for 6 days. After that period, if user or organisation does not accept the request, you will remain the owner of the project.
@@ -58,11 +58,11 @@ There is an option to transfer the ownership of a project to another user or org
 ![transfer project](./project-transfer.png)
 
 ## Delete a project
-If you want to delete a project, you can do so through <MainDomainNameLink /> or using the <QGISPluginName />.
+If you want to delete a project, you can do so through <AppDomainNameLink /> or using the <QGISPluginName />.
 
 ### Delete a project through merginmaps.com
 
-1. Log in <MainDomainNameLink /> and choose the project you want to delete
+1. Log in <AppDomainNameLink /> and choose the project you want to delete
 2. Go to **Settings** and click on **Delete project**
 
 ![delete project](./project-delete.png)

--- a/src/manage/project-advanced.md
+++ b/src/manage/project-advanced.md
@@ -60,7 +60,7 @@ There is an option to transfer the ownership of a project to another user or org
 ## Delete a project
 If you want to delete a project, you can do so through <MainDomainNameLink /> or using the <QGISPluginName />.
 
-### Delete a project through cloudmergin.com
+### Delete a project through merginmaps.com
 
 1. Log in <MainDomainNameLink /> and choose the project you want to delete
 2. Go to **Settings** and click on **Delete project**

--- a/src/manage/project-details.md
+++ b/src/manage/project-details.md
@@ -2,7 +2,7 @@
 
 In Mergin, you can see the details of the changes made to the project from different devices or users. Each time you sync the project from your mobile device or from QGIS through the plugin, a new version will be created.
 
-On <MainDomainNameLink />, you can view what files have been added or removed. If you use GeoPackage for your survey, you can also see the list the features which have been added, deleted or updated.
+On <AppDomainNameLink />, you can view what files have been added or removed. If you use GeoPackage for your survey, you can also see the list the features which have been added, deleted or updated.
 
 To view the project history:
 

--- a/src/misc/contribute.md
+++ b/src/misc/contribute.md
@@ -53,5 +53,5 @@ or for other subprojects
 ## Donate or subscribe
 
  - Donate
- - [Subscribe](https://public.cloudmergin.com) to the Mergin Cloud
+ - [Subscribe](https://merginmaps.com/) to the Mergin Cloud
  - Sponsor a bug-fixing sprint, or a new feature

--- a/src/misc/contribute.md
+++ b/src/misc/contribute.md
@@ -53,5 +53,5 @@ or for other subprojects
 ## Donate or subscribe
 
  - Donate
- - [Subscribe](https://merginmaps.com/) to the Mergin Cloud
+ - <AppDomainNameLink  desc="Subscribe" /> to the <MainPlatformName />
  - Sponsor a bug-fixing sprint, or a new feature

--- a/src/misc/licensing.md
+++ b/src/misc/licensing.md
@@ -4,7 +4,7 @@
 
 ## Mergin Service
 
-* <MainDomainNameLink desc="Mergin Cloud" />, SaaS Mergin service,  has proprietary license held by Lutra Consulting Ltd.
+* <AppDomainNameLink desc="Mergin Maps Cloud" />, SaaS Mergin service,  has proprietary license held by Lutra Consulting Ltd.
 * Mergin EE (Enterprise Edition), on-premise Mergin service, has proprietary license held by Lutra Consulting Ltd.
 * <GitHubRepo id="lutraconsulting/mergin" desc="Mergin CE (Community Edition)" />, on-premise Mergin service, is licensed under AGPL-3.0.
 

--- a/src/misc/troubleshoot.md
+++ b/src/misc/troubleshoot.md
@@ -14,7 +14,7 @@ Please see the <LutraConsultingWeb id="support/" desc="support packages" /> avai
 
 ### Subscribed client support
 
-If you have an active subscription on <MainDomainNameLink />, we also offer free standard support on <MerginMapsEmail id="support" />.
+If you have an active subscription on <AppDomainNameLink />, we also offer free standard support on <MerginMapsEmail id="support" />.
 
 ### Community support
 - Join our [community chat on Slack](https://merginmaps.com/community/join) and ask questions!

--- a/src/misc/write-docs/index.md
+++ b/src/misc/write-docs/index.md
@@ -359,7 +359,11 @@ Use `<AppDownload />` component
 
 ### Naming Mergin Maps Components
 
+Use `<AppDomainNameLink />` component, transforms to <AppDomainNameLink />
+
 Use `<MainDomainName />` component, transforms to <MainDomainName />
+
+Use `<MainDomainNameLink />` component, transforms to <MainDomainNameLink />
 
 Use `<MainPlatformName />` component, transforms to <MainPlatformName />
 

--- a/src/setup/sign-up-to-mergin-maps/index.md
+++ b/src/setup/sign-up-to-mergin-maps/index.md
@@ -60,12 +60,9 @@ check your SPAM folder if the confirmation email does not appear in your inbox a
 
 
 ## Forgotten password
-
-If you forget your password, you can reset it through the [Mergin website](https://app.merginmaps.com/login/reset).
-
+If you forget your password, you can reset it through the <AppDomainNameLink id="login/reset" desc="Mergin website"  />. 
 
 ## Next steps
-
 Welcome to <MainPlatformName />!
 
 You can get up-to-speed quickly by following our [Quick Start tutorials](../../tutorials/capturing-first-data/index.md).

--- a/src/setup/sign-up-to-mergin-maps/index.md
+++ b/src/setup/sign-up-to-mergin-maps/index.md
@@ -61,7 +61,7 @@ check your SPAM folder if the confirmation email does not appear in your inbox a
 
 ## Forgotten password
 
-If you forget your password, you can reset it through the <MainDomainNameLink id="login/reset" desc="Mergin website" />.
+If you forget your password, you can reset it through the [Mergin website](https://app.merginmaps.com/login/reset).
 
 
 ## Next steps

--- a/src/setup/subscriptions/index.md
+++ b/src/setup/subscriptions/index.md
@@ -2,7 +2,7 @@
 
 Mergin Service offers a free plan for up to 100 MB data usage. Free plan can be used to host projects for commercial use only *for first month*. Non-commercial use is considered for personal (hobby) use, or in academia (teachers, students).
 
-We offer discounts for non-profit or charity organisations, please <MerginMapsEmail id="sales" desc="contact us" />
+We offer discounts for non-profit or charity organisations, please <MerginMapsEmail id="sales" desc="contact us" />.
 
 For more storage you can choose one of the two plans for users ("Individual" 1GB or "Professional" 10GB storage) or a plan for an organisation ("Team" 50GB storage).
 

--- a/src/tutorials/capturing-first-data/index.md
+++ b/src/tutorials/capturing-first-data/index.md
@@ -14,11 +14,11 @@ Download <MobileAppName /> to your Android device, iPhone or iPad. You can find 
 
 <AppDownload></AppDownload>
 
-Once you have installed and opened Input you will see two tour projects:
+Once you have installed and opened <MobileAppName /> you will see two tour projects:
 
 ![Input's Tour Projects](./input-tour-projects.png)
 
-These tours introduce the basics of Input.
+These tours introduce the basics of <MobileAppName />.
 
 ![Welcome to Input](./welcome-to-input.png)
 


### PR DESCRIPTION
fix #173 replaced main platform name in text and also in **vuepress components**. Please check if I did that correctly.
The component <MainDomainNameLink /> refers to merginmaps.com, although there was an instance (https://merginmaps.com/docs/setup/sign-up-to-mergin-maps/#forgotten-password) which would need "app.merginmaps.com". In other cases, it seems to me to better link the main page (merginmaps.com) rather than the login page (app.merginmaps.com).
There are still 2 references to cloudmergin.com:
- https://merginmaps.com/docs/layer/plugin-variables/ - I tried this in QGIS and the variable '@mergin_url' still refers to https://public.cloudmergin.com in QGIS, so I did not change it in this docs yet
- https://merginmaps.com/docs/dev/integration/ is maybe a similar case: " --url       Mergin url      (defaults to public.cloudmergin.com)". This is still valid?