### PR TITLE
fix #189 removed warning

### DIFF
--- a/src/layer/settingup_forms_photo.md
+++ b/src/layer/settingup_forms_photo.md
@@ -48,10 +48,6 @@ To set up a custom folder:
 
 ![](./qgis_custom_folder.png)
 
-:::warning
-Empty subfolders in the project folder are currently not synchronised. If you create a new (empty) subfolder for photos, place there some small file, e.g. an empty text file to ensure the sub-folder is synchronised to <MobileAppName />.
-:::
-
 ## Resizing pictures
 Photos that are captured during the field survey or uploaded using <MobileAppName /> can be automatically resized, e.g. to save up storage space. The quality of the photos can be set up in the [Mergin Maps project properties](../gis/features/#photo-quality) using <QGISPluginName />.
 


### PR DESCRIPTION
fix #189 
Warning about syncing empty folders + workaround removed from https://dev.merginmaps.com/docs/layer/settingup_forms_photo/ (did not get to master).

This should be merged after Input 1.5.2 release.