### PR TITLE
fix #231 project transfer expanded

### DIFF
--- a/src/manage/project-advanced.md
+++ b/src/manage/project-advanced.md
@@ -48,12 +48,17 @@ If you change your mind, you can similarly make your project private by clicking
 
 There is an option to transfer the ownership of a project to another user or organisation. 
 
-1. Log in <AppDomainNameLink /> and choose the project you want to transfer
-2. Go to **Settings** and click on **Transfer project**
+1. Make sure to correctly synchronise all changes from your collaborators and devices. If you fail to do that, their local changes will be lost!
+2. After the synchronisation, all collaborators have to **remove** the project from their devices
+3. Log in to <AppDomainNameLink /> and choose the project you want to transfer
+4. Go to **Settings** and click on **Transfer project**
    ![transfer project](./project-transfer.png)
-3. Enter the name of a user/organisation and **Request transfer**
+5. Enter the name of a user/organisation and **Request transfer**
    ![transfer project](./project-transfer2.png)
-4. The user/organisation will be notified to accept or reject the transfer request. The request is valid for 6 days. After that period, if the user or organisation does not accept the request, you will remain the owner of the project.
+   
+   The user/organisation will be notified to accept or reject the transfer request. The request is valid for 6 days. After that period, if the user or organisation does not accept the request, you will remain the owner of the project.
+
+6. After the project transfer, the collaborators have to **download the transferred project** once again from the new owner.
 
 ## Delete a project
 If you want to delete a project, you can do so through <AppDomainNameLink /> or using the <QGISPluginName />.


### PR DESCRIPTION
fix #231 expanded docs for project transfer, added steps to https://merginmaps.com/docs/manage/project-advanced/#transfer-a-project (similar as in https://merginmaps.com/docs/manage/deploy-new-project/#using-a-new-project-after-revisions )