### PR TITLE
fix #256 added links to manual data download + improved troubleshooting

### DIFF
--- a/src/field/autosync/index.md
+++ b/src/field/autosync/index.md
@@ -4,15 +4,17 @@
 
 Changes in your project can be synchronised during the survey manually by using the sync button or automatically by allowing the automatic synchronisation in <MobileAppName />. 
 
+To be able to synchronise a project, you need to:
+- be signed in to your Mergin account
+- be connected to the internet
+- have write [permission](../../manage/permissions/) to the project
+
 The sync button is displayed in the map window.
 
 ![sync button](../input-autosync.png)
 
 :::tip
-To be able to synchronise a project, you need to:
-- be signed in to your Mergin account
-- be connected to the internet
-- have write [permission](../../manage/permissions/) to the project
+Are you missing some data after synchronisation? [How to Recover Missing Data](../../manage/missing-data/) will show you how to deal with [conflict files](../../manage/missing-data/#there-are-conflict-files-in-the-folder) and how to [manually download](../../manage/missing-data/#there-are-no-conflict-files-in-the-folder) data from your mobile device.
 :::
 
 ## Manual synchronisation

--- a/src/misc/troubleshoot.md
+++ b/src/misc/troubleshoot.md
@@ -1,6 +1,16 @@
 # Troubleshoot
-
 [[toc]]
+
+Did you encounter an issue when using <MainPlatformName />? Here are some troubleshooting tips and resources that can help:
+- Do you have enough storage? Check your [subscription and data usage](../manage/dashboard/#subscription).
+- Are you missing some data after synchronisation? [How to Recover Missing Data](../../manage/missing-data/) will show you how to deal with [**conflict files**](../../manage/missing-data/#there-are-conflict-files-in-the-folder) and how to [**manually download**](../../manage/missing-data/#there-are-no-conflict-files-in-the-folder) data from your mobile device.
+- Modifying data schema of survey layers is a common source of synchronisation issues. [How to Deploy Revised Projects](..//manage/missing-data/) will instruct you how to do it correctly.
+- if <MobileAppName /> cannot open your project, see [How to Fix a Broken Project](../field/broken-project/).
+- if <MobileAppName /> displays **PROJ error**, see [Custom Projections](../gis/proj/).
+
+Need more help with your issue? <LutraConsultingWeb /> provides commercial support and free standard support for active subscriptions.
+
+<CommunityJoin />
 
 ## Support
 


### PR DESCRIPTION
fix #256 
- added links to  [How to recover missing data](https://merginmaps.com/docs/manage/missing-data/) added to [synchronisation in Input](https://merginmaps.com/docs/field/autosync/) and to [Troubleshoot](https://merginmaps.com/docs/misc/troubleshoot/)
- [Troubleshoot](https://merginmaps.com/docs/misc/troubleshoot/) now includes also links to other potentionally relevant pages
