### PR TITLE
main-platform-name-link component

### DIFF
--- a/src/.vuepress/components/MainPlatformName.vue
+++ b/src/.vuepress/components/MainPlatformName.vue
@@ -1,3 +1,19 @@
 <template>
-  <span class="nospellcheck">Mergin Maps</span>
+  <a :href="`https://merginmaps.com/${id}`" target="_blank" class="nospellcheck">
+    <span v-if="desc" v-html="desc"></span>
+    <span v-else class="nospellcheck">Mergin Maps</span>
+  </a>
 </template>
+
+<script>
+export default {
+  name: "maindomainnamelink",
+  props: {
+    id: {
+      type: String,
+      default: ''
+    },
+    desc: String
+  }
+}
+</script>

--- a/src/.vuepress/components/MainPlatformName.vue
+++ b/src/.vuepress/components/MainPlatformName.vue
@@ -1,19 +1,3 @@
 <template>
-  <a :href="`https://merginmaps.com/${id}`" target="_blank" class="nospellcheck">
-    <span v-if="desc" v-html="desc"></span>
-    <span v-else class="nospellcheck">Mergin Maps</span>
-  </a>
+  <span class="nospellcheck">Mergin Maps</span>
 </template>
-
-<script>
-export default {
-  name: "maindomainnamelink",
-  props: {
-    id: {
-      type: String,
-      default: ''
-    },
-    desc: String
-  }
-}
-</script>

--- a/src/.vuepress/components/MainPlatformNameLink.vue
+++ b/src/.vuepress/components/MainPlatformNameLink.vue
@@ -1,0 +1,19 @@
+<template>
+  <a :href="`https://merginmaps.com/${id}`" target="_blank" class="nospellcheck">
+    <span v-if="desc" v-html="desc"></span>
+    <span v-else class="nospellcheck">Mergin Maps</span>
+  </a>
+</template>
+
+<script>
+export default {
+  name: "maindomainnamelink",
+  props: {
+    id: {
+      type: String,
+      default: ''
+    },
+    desc: String
+  }
+}
+</script>

--- a/src/.vuepress/components/MainPlatformNameNoLink.vue
+++ b/src/.vuepress/components/MainPlatformNameNoLink.vue
@@ -1,0 +1,3 @@
+<template>
+  <span class="nospellcheck">Mergin Maps</span>
+</template>

--- a/src/.vuepress/components/MainPlatformNameNoLink.vue
+++ b/src/.vuepress/components/MainPlatformNameNoLink.vue
@@ -1,3 +1,0 @@
-<template>
-  <span class="nospellcheck">Mergin Maps</span>
-</template>

--- a/src/dev/customapp.md
+++ b/src/dev/customapp.md
@@ -1,6 +1,6 @@
 # Custom Mobile App
 
-Our mobile app <MobileAppName /> provides seamless synchronisation of field data between mobile devices and <MainPlatformName /> service. However, we know that sometimes people want a mobile app optimised for a specific use case: maybe you just want to change the branding or disable some functionality - or maybe you want a bigger overhaul of the user interface. 
+Our mobile app <MobileAppName /> provides seamless synchronisation of field data between mobile devices and <MainPlatformNameLink /> service. However, we know that sometimes people want a mobile app optimised for a specific use case: maybe you just want to change the branding or disable some functionality - or maybe you want a bigger overhaul of the user interface. 
 
 The good news is that <MobileAppName /> is licensed as open source software, which means that anything is possible with a bit of development!
 

--- a/src/dev/dbsync.md
+++ b/src/dev/dbsync.md
@@ -1,5 +1,5 @@
 # PostgreSQL DB Sync
 
-DB Sync is a tool that takes care of two-way synchronisation between <MainPlatformName /> and PostGIS databases. The synchronisation works both ways: changes made in a PostGIS database are automatically pushed to a configured <MainPlatformName /> project and changes made in a GeoPackage in the <MainPlatformName /> project are pushed to the PostGIS database.
+DB Sync is a tool that takes care of two-way synchronisation between <MainPlatformNameLink /> and PostGIS databases. The synchronisation works both ways: changes made in a PostGIS database are automatically pushed to a configured <MainPlatformName /> project and changes made in a GeoPackage in the <MainPlatformName /> project are pushed to the PostGIS database.
 
 **Interested in using DB Sync?** Go to <GitHubRepo id="MerginMaps/mergin-db-sync" /> repository for the source code and more details. Here, you will also find the Quick start guide that will show you how to set up one way synchronisation between your PostGIS database and a new <MainPlatformName /> project.

--- a/src/dev/geodiff/index.md
+++ b/src/dev/geodiff/index.md
@@ -1,7 +1,7 @@
 # Geodiff Library
 [[toc]]
 
-Geodiff is a library for handling differences of spatial data. It can be used to compare two datasets to get and apply changesets or to merge changes from multiple sources. In <MainPlatformName />, Geodiff is used to synchronise changes made by individual team members, see [Behind Data Synchronisation](../../manage/synchronisation/). 
+Geodiff is a library for handling differences of spatial data. It can be used to compare two datasets to get and apply changesets or to merge changes from multiple sources. In <MainPlatformNameLink />, Geodiff is used to synchronise changes made by individual team members, see [Behind Data Synchronisation](../../manage/synchronisation/). 
 
 Geodiff works with GeoPackage files and PostGIS databases as well as with non-spatial SQLite and PostgreSQL databases. That means one can seamlessly find differences between tables of two schemas in a PostGIS database and apply the changes to a GeoPackage (or vice versa). Thanks to that, it is possible to keep data in sync even if the back-ends are completely different.
 

--- a/src/dev/integration.md
+++ b/src/dev/integration.md
@@ -1,10 +1,10 @@
 # Integrate Mergin Maps
 [[toc]]
 
-<MainPlatformName /> is an open platform that aims to be developer friendly and it has been designed to allow easy integration with other software.
+<MainPlatformNameLink /> is an open platform that aims to be developer friendly and it has been designed to allow easy integration with other software.
 
 ## Python client module
-The Python client module is the easiest way to programmatically use <MainPlatformName />. You can use Python API or a command-line tool to easily work with <MainPlatformName /> projects, such as to get project status, push and pull changes, or to download, create and delete projects.
+The Python client module is the easiest way to programmatically use <MainPlatformNameLink />. You can use Python API or a command-line tool to easily work with <MainPlatformName /> projects, such as to get project status, push and pull changes, or to download, create and delete projects.
 
 The <GitHubRepo id="MerginMaps/mergin-py-client" /> repository contains the source code of the Python client module and more information on how to use it.
 
@@ -15,7 +15,7 @@ pip3 install mergin-client
 ```
 
 ### Python module 
-To use <MainPlatformName /> from Python, just create `MerginClient` object and then use it. Here, for instance, to download a project:
+To use <MainPlatformNameLink /> from Python, just create `MerginClient` object and then use it. Here, for instance, to download a project:
 
 ```python
 import mergin

--- a/src/dev/media-sync/index.md
+++ b/src/dev/media-sync/index.md
@@ -1,7 +1,7 @@
 # Media Sync
 [[toc]]
 
-Media Sync enables to synchronise media files from <MainPlatformName /> project to other storage back-ends, such as Amazon S3 or <NoSpellcheck id="MinIO" />. 
+Media Sync enables to synchronise media files from <MainPlatformNameLink /> project to other storage back-ends, such as Amazon S3 or <NoSpellcheck id="MinIO" />. 
 
 Media Sync has two sync modes: in copy mode, media files are only copied the external drive, while in the move mode, the files are copied and subsequently removed from <MainPlatformName /> project.
 

--- a/src/dev/mergince.md
+++ b/src/dev/mergince.md
@@ -1,6 +1,6 @@
 # Mergin Maps Community Edition
 
-The <MainDomainNameLink /> is a web platform for storage and synchronisation of data between mobile devices, <MainPlatformName /> service and QGIS Desktop.
+<MainPlatformNameLink /> is a web platform for storage and synchronisation of data between mobile devices, <MainPlatformNameLink /> service and QGIS Desktop.
 
 The good news is that <MainPlatformName /> Community Edition (<MainPlatformName /> CE) is licensed as open source software and therefore it is possible to do your custom deployments.
 

--- a/src/dev/work-packages/index.md
+++ b/src/dev/work-packages/index.md
@@ -1,9 +1,9 @@
 # Work Packages
 [[toc]]
 
-The <MainPlatformName /> Work Packages tool is designed to manage field surveys for multiple teams. This tool allows to create <MainPlatformName /> *work packages projects* that contain a subset of data of the main <MainPlatformName /> project and set up two-way synchronisation between the main project and the dependent projects as illustrated here:
+The <MainPlatformNameLink/> Work Packages tool is designed to manage field surveys for multiple teams. This tool allows to create <MainPlatformName /> *work packages projects* that contain a subset of data of the main <MainPlatformNameLink/> project and set up two-way synchronisation between the main project and the dependent projects as illustrated here:
 ![work packages](./wp-high-level.png)
 
-The main <MainPlatformName /> project (*Survey*) contains all data. The admin of the main project can assign some of the data to working package projects (*Survey Team A*, *Survey Team B*). The teams can see and modify only the data that are assigned to them.
+The main <MainPlatformNameLink/> project (*Survey*) contains all data. The admin of the main project can assign some of the data to working package projects (*Survey Team A*, *Survey Team B*). The teams can see and modify only the data that are assigned to them.
 
 **Interested in using Work Packages?** Go to <GitHubRepo id="MerginMaps/mergin-work-packages" /> repository for the source code, more details and a quick start with a simple project.

--- a/src/field/autosync/index.md
+++ b/src/field/autosync/index.md
@@ -5,7 +5,7 @@
 Changes in your project can be synchronised during the survey manually by using the sync button or automatically by allowing the automatic synchronisation in <MobileAppName />. 
 
 To be able to synchronise a project, you need to:
-- be signed in to your <MainPlatformName /> account
+- be signed in to your <MainPlatformNameLink /> account
 - be connected to the internet
 - have write [permission](../../manage/permissions/) to the project
 

--- a/src/field/input_features.md
+++ b/src/field/input_features.md
@@ -95,7 +95,7 @@ If you want to delete the feature, tap on it and press the edit button. Here you
 ![Edit and delete](./input-delete.png)
 
 ## Synchronise changes
-Don't forget to upload your changes to <MainPlatformName />!
+Don't forget to upload your changes to <MainPlatformNameLink />!
 
 Synchronisation in <MobileAppName /> can be done automatically or manually by pressing the sync button. For more details visit [Synchronisation in Input](./autosync/).
 

--- a/src/field/input_ui.md
+++ b/src/field/input_ui.md
@@ -12,7 +12,7 @@ There are four tabs available in the bottom navigation panel: [Projects](#projec
 ## Projects
 **Projects** tab is where you can create a new project, upload it to the cloud, synchronise changes, or remove a local project from your device.
 - **Home**: a list of all downloaded projects on your device. Only downloaded projects can be opened in the app.
-- **My projects**: projects created by you and hosted on the <MainPlatformName /> service
+- **My projects**: projects created by you and hosted on the <MainPlatformNameLink /> service
 - **Shared with me**: projects on the <MainPlatformName /> service shared with you by other users
 - **Explore**: a full list of public projects by others on the <MainPlatformName /> service
 

--- a/src/field/layers/index.md
+++ b/src/field/layers/index.md
@@ -2,7 +2,7 @@
 <Badge text="since Input 1.9.0" type="tip"/>
 [[toc]]
 
-**Layers** panel provides an overview of layers and features in your <MainPlatformName /> project in <MobileAppName />, as well as the option to turn the visibility of specific layers on/off or to see a layer's legend.
+**Layers** panel provides an overview of layers and features in your <MainPlatformNameLink /> project in <MobileAppName />, as well as the option to turn the visibility of specific layers on/off or to see a layer's legend.
 
 ![input layers](./input-layers.png)
 

--- a/src/gis/settingup_background_map.md
+++ b/src/gis/settingup_background_map.md
@@ -1,7 +1,7 @@
 # Background Maps
 [[toc]]
 
-When surveying in the field, it is essential to have appropriate background maps. There are several sources of online and offline background maps you can use in your QGIS project. Note that you need to comply with the terms of use of the background maps and their data sources. This page simply explains how to add the data to your QGIS maps and use it in <MobileAppName />. It is the sole responsibility of the end user to comply with such terms and conditions.
+When surveying in the field, it is essential to have appropriate background maps. There are several sources of online and offline background maps you can use in your QGIS project. Note that you need to comply with the terms of use of the background maps and their data sources. This page simply explains how to add the data to your QGIS maps and use it in <MainPlatformNameLink />. It is the sole responsibility of the end user to comply with such terms and conditions.
 
 The following sections will cover two types of background maps for online and offline use in <MobileAppName />: raster and vector tiles.
 
@@ -110,7 +110,7 @@ Note that instructions below require familiarity with the terminal. In addition,
 ## How to work with very large files (Android)
 <Badge text="Android only" type="warning"/>
 
-Raster and vector tiles generated for offline use can be relatively large files, especially when using high resolution data or a large area of interest. It may be impractical to synchronise these large files through <MainPlatformName /> or to have duplicate copies if they are used in multiple projects.
+Raster and vector tiles generated for offline use can be relatively large files, especially when using high resolution data or a large area of interest. It may be impractical to synchronise these large files through <MainPlatformNameLink /> or to have duplicate copies if they are used in multiple projects.
 
 :::tip
 If you do not need to use your background maps offline, consider creating a WMS or WMTS server for online use.
@@ -133,5 +133,5 @@ Files from the folder can be loaded into multiple <MainPlatformName /> projects.
 :::
 
 :::warning
-Files located in the another folder are not synchronised. This saves your storage on <MainPlatformName /> cloud. However, if you want to update or modify these files, you have to connect the mobile device to your computer and do it manually.
+Files located in the another folder are not synchronised. This saves your storage on <MainPlatformNameLink /> cloud. However, if you want to update or modify these files, you have to connect the mobile device to your computer and do it manually.
 :::

--- a/src/index.md
+++ b/src/index.md
@@ -5,9 +5,9 @@ home: false
 
 # Mergin Maps Documentation
 
-- Store and track changes to your geo-data with <MainPlatformName /> :cd:
+- Store and track changes to your geo-data with <MainPlatformNameLink /> :cd:
 - Capture geo-info easily through your mobile or tablet with <MobileAppName /> :iphone:
-- Setup and analyse the project on desktop with QGIS :computer:
+- Setup and analyse the project on desktop with [QGIS](https://qgis.org/) :computer:
 - All open-source and easily integrated to your existing toolset :bulb:
 
 <CommunityJoin />
@@ -15,7 +15,7 @@ home: false
 The ecosystem consist of various components:
  - [QGIS](https://qgis.org/) > Powerful GIS Desktop application 
  - [<QGISPluginName />](https://plugins.qgis.org/plugins/Mergin/) > QGIS plugin
- - <MainDomainNameLink desc="Mergin Maps Cloud" /> > SaaS Cloud Service (available also as Mergin CE)
+ - <MainDomainNameLink desc="Mergin Maps Cloud" /> > SaaS Cloud Service (available also as <MainPlatformName /> CE)
  - <MainDomainNameLink desc="Mergin Maps Input" /> > iOS and Android mobile app
  
 ## Get started 

--- a/src/layer/plugin-variables.md
+++ b/src/layer/plugin-variables.md
@@ -4,7 +4,7 @@ The plugin adds several variables that can be used in QGIS expressions:
 
 | Variable name               | Sample value                     | Scope   | Description |
 |-----------------------------|----------------------------------|---------|-------------|
-| `@mergin_username`          | `martin`                         | global  | Name of the user currently logged in to <MainPlatformName /> |
+| `@mergin_username`          | `martin`                         | global  | Name of the user currently logged in to <MainPlatformNameLink /> |
 | `@mergin_url`               | `https://app.merginmaps.com` | global  | URL of the <MainPlatformName /> service |
 | `@mergin_project_name`      | `Tree survey`                    | project | Name of the active <MainPlatformName /> project  |
 | `@mergin_project_owner`     | `martin`                         | project | Name of the owner of the active project |

--- a/src/manage/create-project/index.md
+++ b/src/manage/create-project/index.md
@@ -3,7 +3,7 @@
 
 There are several methods of creating a new <MainPlatformName /> project:
 - [<MobileAppName /> ](./index.md#create-a-project-in-mergin-maps-input) offers the quickest (albeit limited) way of creating a <MainPlatformName /> project.
-- If you want to take full advantage of <MainPlatformName />, use [QGIS](./index.md#create-a-project-in-qgis) to prepare new projects.
+- If you want to take full advantage of <MainPlatformNameLink />, use [QGIS](./index.md#create-a-project-in-qgis) to prepare new projects.
 - You can also use [merginmaps.com](./index.md#create-a-project-through-merginmaps-com), especially if your project files are already fully prepared and only need uploading.
 
 If you want to make a copy of your projects or the ones shared with you, you can clone them in [QGIS](./index.md#clone-an-existing-project-in-qgis) or [merginmaps.com](./index.md#clone-an-existing-project-through-merginmaps-com).
@@ -28,7 +28,7 @@ Your new project should now be visible on the **Home** tab of the **Projects** s
 
 ## Create a project in QGIS
 ::: tip
-[Creating a Project in QGIS](../../tutorials/creating-a-project-in-qgis/index.md) tutorial will show you how to create a new project in QGIS, add layers, configure attributes forms and save changes to <MainPlatformName />. 
+[Creating a Project in QGIS](../../tutorials/creating-a-project-in-qgis/index.md) tutorial will show you how to create a new project in QGIS, add layers, configure attributes forms and save changes to <MainPlatformNameLink />. 
 :::
 
 To work with <MainPlatformName /> projects in QGIS, you will need to [install the <QGISPluginName />](../../setup/install-mergin-maps-plugin-for-qgis/index.md) first.
@@ -53,7 +53,7 @@ To work with <MainPlatformName /> projects in QGIS, you will need to [install th
    Your project should be saved on a local drive. Using shared network drives and cloud storage (such as OneDrive or Google Drive) is **not supported**.
    :::
 
-The new <MainPlatformName /> project will be created locally on your computer and also on the <MainPlatformName /> server. 
+The new <MainPlatformName /> project will be created locally on your computer and also on the <MainPlatformNameLink /> server. 
 
 ### Clone an existing project in QGIS
 Using <QGISPluginName />, you can make a copy of one of your existing projects or the ones shared with you. 

--- a/src/manage/delete-files/index.md
+++ b/src/manage/delete-files/index.md
@@ -1,6 +1,6 @@
 # How to Delete Files
 
-Deleting files such as photos that are not needed anymore can help you free up storage on the <MainPlatformName /> cloud and keep your project organised.
+Deleting files such as photos that are not needed anymore can help you free up storage on the <MainPlatformNameLink /> cloud and keep your project organised.
 
 Files can be deleted through <AppDomainNameLink /> one by one. Deleting multiple files at once is possible on your computer using <QGISPluginName />.
 [[toc]]

--- a/src/manage/deploy-new-project/index.md
+++ b/src/manage/deploy-new-project/index.md
@@ -10,7 +10,7 @@ Sometimes you may need to make changes in your project. Changing **forms** by ad
 However, you should be extra careful, if you are **modifying the data schema** of your survey layer, such as adding new fields or changing data type of a field. Data schema changes can cause synchronisation issues - to avoid them, you need to deploy the revised project properly. Here, we provide two options on how to do it. Choose the one that fits better with your workflow and your ability to coordinate with your team.
 
 :::warning
-Always make sure that the project on <MainPlatformName /> is up-to-date with all the changes before data admin proceeds with change in GeoPackage data schema.
+Always make sure that the project on <MainPlatformNameLink /> is up-to-date with all the changes before data admin proceeds with change in GeoPackage data schema.
 :::
 
 ## Using a new project after revisions
@@ -19,7 +19,7 @@ One way how to make sure the modified project is distributed correctly is to cre
 2. After the synchronisation, the project needs to be **removed** from all devices
 3. [Clone](../create-project/#clone-an-existing-project-in-qgis) your survey project
 4. Modify the data schema
-5. Push the revised project to <MainPlatformName /> as a **new project**
+5. Push the revised project to <MainPlatformNameLink /> as a **new project**
 6. Ask your team members to **use the new project** 
 
 ::: tip

--- a/src/manage/permissions.md
+++ b/src/manage/permissions.md
@@ -1,10 +1,10 @@
 # Permissions
 
-There are several levels of permissions to control access to your projects in <MainPlatformName />.
+There are several levels of permissions to control access to your projects in <MainPlatformNameLink />.
 
 ## Public and private projects
 
-A private project is a project that only you and those who you choose to share the project with will have access to the files, history and settings. A public project is a project that everyone (including those who are not registered with <MainPlatformName />) can view the data and project history. They cannot contribute to your public project unless you have shared the project with them with write access (see below for permissions)
+A private project is a project that only you and those who you choose to share the project with will have access to the files, history and settings. A public project is a project that everyone (including those who are not registered with <MainPlatformNameLink />) can view the data and project history. They cannot contribute to your public project unless you have shared the project with them with write access (see below for permissions)
 
 ## Project permissions
 

--- a/src/manage/plugin-multi-server-use/index.md
+++ b/src/manage/plugin-multi-server-use/index.md
@@ -4,12 +4,12 @@
 There is a default server <AppDomainNameLink /> which is configured in <QGISPluginName />. However, in some cases you might want to use some custom server, e.g. when you host it yourself.
 
 ## Custom server configuration
-If you want to use a custom <MainPlatformName /> server, you will need to configure it in <QGISPluginName />.
+If you want to use a custom <MainPlatformNameLink /> server, you will need to configure it in <QGISPluginName />.
 
-1. Click on the **Configure Mergin Maps plugin** icon to open the configuration dialog
+1. Click on the **Configure <MainPlatformName /> plugin** icon to open the configuration dialog
 ![configure icon](./configure-plugin.png)
 
-2. Check the **Custom Mergin Maps server** option and enter your custom server URL.
+2. Check the **Custom <MainPlatformName /> server** option and enter your custom server URL.
 ![config dialog](./config_dialog.png)
 
 Now, the server URL is saved in current QGIS profile settings. So whenever you open QGIS with this profile, the <MainPlatformName /> server is associated with this URL. 

--- a/src/manage/plugin-sync-project.md
+++ b/src/manage/plugin-sync-project.md
@@ -1,11 +1,11 @@
 # Mergin Maps Plugin for QGIS Overview
 [[toc]]
 
-<QGISPluginName /> allows you to work with your Mergin Maps projects in QGIS, whether it's downloading the project to your computer, making changes in the project, seeing the project's status or synchronising changes to the cloud. 
+Our <QGISPluginName /> allows you to work with your <MainPlatformNameLink /> projects in QGIS, whether it's downloading the project to your computer, making changes in the project, seeing the project's status or synchronising changes to the cloud. 
 
 To get started, you will need to [install and configure the plugin](../setup/install-mergin-maps-plugin-for-qgis/index.md).
 
-Once you have configured the plugin with your Mergin Maps credentials, you should be able to see the following sections under the Mergin Maps in your QGIS Browser panel:
+Once you have configured the plugin with your <MainPlatformNameLink /> credentials, you should be able to see the following sections under the **<MainPlatformName />** in your QGIS Browser panel:
 - **My projects** lists all projects you have created
 - **Shared with me** lists the projects that are shared with you (including your organisation projects)
 - **Explore** lists all the public projects

--- a/src/manage/project-advanced.md
+++ b/src/manage/project-advanced.md
@@ -3,7 +3,7 @@
 
 ## Share a project
 
-Through <AppDomainNameLink />, you can share your project with other <MainPlatformName /> users. You can add your coworkers manually or send them a link and manage their permissions in your private project. You can also make your project accessible to everyone by making it public.
+Through <AppDomainNameLink />, you can share your project with other <MainPlatformNameLink /> users. You can add your coworkers manually or send them a link and manage their permissions in your private project. You can also make your project accessible to everyone by making it public.
 
 ::: tip
 You can follow our [Working collaboratively](../tutorials/working-collaboratively/) tutorial to see detailed instructions on how to share your project.

--- a/src/manage/project-details.md
+++ b/src/manage/project-details.md
@@ -1,5 +1,5 @@
 # Project History and Versions
-<MainPlatformName /> makes it possible to see the details of the changes made to the project from different devices or users. Each time you sync the project from your mobile device or from QGIS through the plugin, a new version will be created. 
+<MainPlatformNameLink /> makes it possible to see the details of the changes made to the project from different devices or users. Each time you sync the project from your mobile device or from QGIS through the plugin, a new version will be created. 
 
 On <AppDomainNameLink />, you can view what files have been added or removed. If you use GeoPackage for your survey, you can also see the list of the features which have been added, deleted or updated.
 

--- a/src/manage/project/index.md
+++ b/src/manage/project/index.md
@@ -5,7 +5,7 @@ What is a <MainPlatformName /> project?
 
 It is basically a folder that contains data (such as vector layers, tables, rasters or photos), a [QGIS project](../../gis/features/), and some extra <MainPlatformName /> files needed to ensure everything works.
 
-When <MainPlatformName /> project is created, it is saved to <MainPlatformName /> cloud. From the cloud, it can be downloaded to various devices, used by different team members in both QGIS and <MobileAppName />. Changes they made are tracked and synchronised back to the cloud.
+When <MainPlatformName /> project is created, it is saved to <MainPlatformNameLink /> cloud. From the cloud, it can be downloaded to various devices, used by different team members in both QGIS and <MobileAppName />. Changes they made are tracked and synchronised back to the cloud.
 
 ## Creating project
 :::tip
@@ -37,7 +37,7 @@ There are three options for handling layers:
    
    ![](../create-project/mergin_plugin_project_wizard_3.png) 
 
-After the layers for the new project are selected, you just need to enter the project's name and choose where to save it on your computer. It will also be saved on the <MainPlatformName /> server.
+After the layers for the new project are selected, you just need to enter the project's name and choose where to save it on your computer. It will also be saved on the <MainPlatformNameLink /> server.
    ![](../create-project/mergin_plugin_project_wizard_4.png)
 
 ### Mergin Maps project folder

--- a/src/manage/selective_sync/index.md
+++ b/src/manage/selective_sync/index.md
@@ -1,6 +1,6 @@
 # Selective Synchronisation
 
-Selective sync feature adds a possibility to not download specified files on other devices in the synchronisation process. These files are only stored on the creator's device and server and can be accessed on <MainPlatformName /> web or QGIS desktop. Other collaborators on different devices will not receive these files during synchronisation.
+Selective sync feature adds a possibility to not download specified files on other devices in the synchronisation process. These files are only stored on the creator's device and server and can be accessed on <MainPlatformNameLink /> web or QGIS desktop. Other collaborators on different devices will not receive these files during synchronisation.
 
 Selective sync is useful mainly when a project contains a lot of data (for example photos) and these data do not necessarily need to be stored on all devices. Another advantage is a significant reduction of synchronisation time.
 

--- a/src/manage/synchronisation.md
+++ b/src/manage/synchronisation.md
@@ -5,20 +5,20 @@
 ## Mergin Maps workflow
 Synchronisation is a key process that makes effective collaboration possible: you and your team members can contribute to the same project simultaneously, see each other's edits and also smoothly transfer data between mobile devices and computers.
 
-Let's look at a typical workflow in <MainPlatformName />:
+Let's look at a typical workflow in <MainPlatformNameLink />:
 1. First, you [create](./create-project/#create-a-project-in-qgis) and [prepare](../gis/features/) a <MainPlatformName /> project in QGIS. This includes loading background and survey layers, setting up the forms, styling layers, setting up map themes and defining the layers to be used in a survey. The <MainPlatformName /> project consists of the project file (*.qgz) and data referenced in the project, such as GeoPackage layers, shapefiles, rasters or attachments. At this point, they are all saved in a project folder in your computer.
-2. The <MainPlatformName /> project is uploaded to <MainPlatformName /> Cloud using [<QGISPluginName />](./plugin-sync-project/). The project and data are now stored in the cloud.
+2. The <MainPlatformName /> project is uploaded to <MainPlatformNameLink /> Cloud using [<QGISPluginName />](./plugin-sync-project/). The project and data are now stored in the cloud.
 3. Now you can work collaboratively! The project and data can be downloaded to a mobile device to do [the fieldwork using <MobileAppName /> ](../tutorials/mobile/) or to another computer with QGIS. Every collaborator works with their own local version of the project.
-4. After finishing their work, the individual contributors synchronise their changes [to Mergin Maps Cloud](../tutorials/mobile/#saving-data-to-the-cloud), where they are put together.
+4. After finishing their work, the individual contributors synchronise their changes [to <MainPlatformName /> Cloud](../tutorials/mobile/#saving-data-to-the-cloud), where they are put together.
 
-As you can see, <MainPlatformName /> Cloud acts as a link between individual contributors and also between PCs and mobile devices, synchronising the changes. When you make changes and upload them to the cloud, <MainPlatformName /> will compare the content of GeoPackage layers and merge them, while copying attachments (such as photos), rasters and shapefiles as they are. That is why we recommend using GeoPackage format for your survey layer.
+As you can see, <MainPlatformName /> Cloud acts as a link between individual contributors and also between PCs and mobile devices, synchronising the changes. When you make changes and upload them to the cloud, <MainPlatformNameLink /> will compare the content of GeoPackage layers and merge them, while copying attachments (such as photos), rasters and shapefiles as they are. That is why we recommend using GeoPackage format for your survey layer.
 
 ::: warning
 Synchronising data and project works in both ways.
 :::
 
 ## Synchronisation
-How does it work? When you use GeoPackage, <MainPlatformName /> compares two datasets with the same data schema using [Geodiff library](#geodiff-library) to create a list of entries that were inserted, updated, or deleted between the two datasets. 
+How does it work? When you use GeoPackage, <MainPlatformNameLink /> compares two datasets with the same data schema using [Geodiff library](#geodiff-library) to create a list of entries that were inserted, updated, or deleted between the two datasets. 
 
 ![geodiff](./geodiff-diff.png)
 
@@ -29,7 +29,7 @@ During field surveys, individual team members can change the same row of a table
 There may be conflicts that can't be resolved automatically, e.g. if the same value is modified in different copies. These rare cases are written to a conflict file that can be [resolved later](./missing-data/#there-are-conflict-files-in-the-folder).
 
 ## Conflict files
-Conflicts can happen when two users edit some files in a shared project at once. The technology behind <MainPlatformName /> service makes an effort to merge changes from individual users automatically and therefore conflicts do not happen normally, even if multiple people edit a single data source (e.g. a GeoPackage). However, there are still some occasions when it is not possible to automatically resolve conflicts and <MainPlatformName /> will create conflict files in projects.
+Conflicts can happen when two users edit some files in a shared project at once. The technology behind <MainPlatformNameLink /> service makes an effort to merge changes from individual users automatically and therefore conflicts do not happen normally, even if multiple people edit a single data source (e.g. a GeoPackage). However, there are still some occasions when it is not possible to automatically resolve conflicts and <MainPlatformName /> will create conflict files in projects.
 
 ::: tip
 Make your work easier and avoid unnecessary conflict files by following [these tips](../layer/best-practice/).
@@ -47,11 +47,11 @@ Let's think of a survey of benches in a park conducted by Jack and Jill. They st
 If Jack is the first one to sync his changes and then Jill syncs her changes, at the time of Jill's sync <MainPlatformName /> knows they have a conflict in edits for that one bench. The editor who syncs last "wins", so in this case Jill's changes would be kept and Jack's changes would be overwritten (of course, all his non-conflicting edits to other benches would be kept). <MainPlatformName /> keeps a record about this, in case a project admin would want to investigate the edit conflict: if the survey is stored e.g. in `data.gpkg`, then a JSON file named data `(edit conflict, jack v123).json` would be created, containing list of conflicts. For each conflicting attribute value, the file lists the original value and the two different modified versions.
 
 ### Conflicted copy
-<MainPlatformName /> cannot detect changes if you change the data schema, such as deleting or adding columns to your survey layer or changing the data type of a field. If you try to synchronise a layer with modified data schema, you will get a conflict file.
+If you change the data schema, such as deleting or adding columns to your survey layer or changing the data type of a field, <MainPlatformName /> cannot detect changes. If you try to synchronise a layer with modified data schema, you will get a conflict file.
 
 If you need to change the data schema, [see how to deploy a revised project properly](./deploy-new-project/).
  
 <!-- TODO: example when that happens (change of database schema) -->
 
 ## Geodiff library
-<MainPlatformName /> uses a library called **Geodiff** to synchronise changes made by individual team members. You can find this library at <GitHubRepo id="MerginMaps/geodiff" /> .
+A library called **Geodiff** is used by <MainPlatformNameLink /> to synchronise changes made by individual team members. You can find this library at <GitHubRepo id="MerginMaps/geodiff" /> .

--- a/src/misc/contribute.md
+++ b/src/misc/contribute.md
@@ -2,7 +2,7 @@
 
 How to contribute to the project? 
 
-We are happy to help to promote work or co-author and place on our websites or give special offer for Mergin Maps Cloud for project contributors.
+We are happy to help to promote work or co-author and place on our websites or give special offer for <MainPlatformNameLink /> Cloud for project contributors.
 
 <CommunityJoin />
 
@@ -14,7 +14,7 @@ Write a review of the application on App Store or Android Google Play
 
 ## Translate
 
-To help with translations, join [Mergin Maps Transifex team](https://www.transifex.com/lutra-consulting/mergin-maps-input/)
+To help with translations, join [<MainPlatformName /> Transifex team](https://www.transifex.com/lutra-consulting/mergin-maps-input/)
 
 ## Write or talk about us 
  

--- a/src/misc/troubleshoot.md
+++ b/src/misc/troubleshoot.md
@@ -1,7 +1,7 @@
 # Troubleshoot
 [[toc]]
 
-Did you encounter an issue when using <MainPlatformName />? Here are some troubleshooting tips and resources that can help:
+Did you encounter an issue when using <MainPlatformNameLink />? Here are some troubleshooting tips and resources that can help:
 - Do you have enough storage? Check your [subscription and data usage](../manage/dashboard/#subscription).
 - Are you missing some data after synchronisation? [How to Recover Missing Data](../../manage/missing-data/) will show you how to deal with [**conflict files**](../../manage/missing-data/#there-are-conflict-files-in-the-folder) and how to [**manually download**](../../manage/missing-data/#there-are-no-conflict-files-in-the-folder) data from your mobile device.
 - Modifying data schema of survey layers is a common source of synchronisation issues. [How to Deploy Revised Projects](..//manage/missing-data/) will instruct you how to do it correctly.

--- a/src/misc/write-docs/index.md
+++ b/src/misc/write-docs/index.md
@@ -367,7 +367,7 @@ Use `<MainDomainNameLink />` component, transforms to <MainDomainNameLink />
 
 Use `<MainPlatformName />` component, transforms to <MainPlatformName />
 
-Use `<MainPlatformNameNoLink />` component, transforms to <MainPlatformNameNoLink />
+Use `<MainPlatformNameLink />` component, transforms to <MainPlatformNameLink />
 
 Use `<MobileAppName />` component, transforms to <MobileAppName />
 

--- a/src/misc/write-docs/index.md
+++ b/src/misc/write-docs/index.md
@@ -367,6 +367,8 @@ Use `<MainDomainNameLink />` component, transforms to <MainDomainNameLink />
 
 Use `<MainPlatformName />` component, transforms to <MainPlatformName />
 
+Use `<MainPlatformNameNoLink />` component, transforms to <MainPlatformNameNoLink />
+
 Use `<MobileAppName />` component, transforms to <MobileAppName />
 
 Use `<QGISPluginName />` component, transforms to <QGISPluginName />

--- a/src/setup/install-mergin-maps-plugin-for-qgis/index.md
+++ b/src/setup/install-mergin-maps-plugin-for-qgis/index.md
@@ -21,7 +21,7 @@ Before the <QGISPluginName /> installation, please ensure you have already:
    :::
 
 ## Plugin configuration
-With the plugin installed, we'll now configure it with your <MainPlatformName /> credentials.
+With the plugin installed, we'll now configure it with your <MainPlatformNameLink /> credentials.
 
 1. Click the **Configure <MainPlatformNameNoLink /> Plugin** icon on the **<MainPlatformNameNoLink /> Toolbar**:
    ![](./qgis-configure-mergin-plugin.jpg)

--- a/src/setup/install-mergin-maps-plugin-for-qgis/index.md
+++ b/src/setup/install-mergin-maps-plugin-for-qgis/index.md
@@ -1,8 +1,8 @@
 # How to Install QGIS Plugin
 [[toc]]
 
-Before the Mergin Maps plugin installation, please ensure you have already:
-* [Signed up to <MainPlatformName />](../sign-up-to-mergin-maps/)
+Before the <QGISPluginName /> installation, please ensure you have already:
+* [Signed up to <MainPlatformNameNoLink />](../sign-up-to-mergin-maps/)
 * [Installed QGIS](../install-qgis/)
 
 ## Plugin installation
@@ -13,17 +13,17 @@ Before the Mergin Maps plugin installation, please ensure you have already:
 3. Find the **Mergin Maps** plugin and click **Install Plugin**:
    ![](./find-and-install-mergin.jpg)
 
-4. Close the Plugins dialog. The Mergin Maps plugin toolbar should appear in QGIS:
+4. Close the Plugins dialog. The <MainPlatformNameNoLink /> plugin toolbar should appear in QGIS:
    ![](./mergin-toolbar.jpg)
    
    ::: tip
-   If you cannot see the toolbar, ensure **Mergin Maps Toolbar** is checked under **View > Toolbars**.
+   If you cannot see the toolbar, ensure **<MainPlatformNameNoLink /> Toolbar** is checked under **View > Toolbars**.
    :::
 
 ## Plugin configuration
 With the plugin installed, we'll now configure it with your <MainPlatformName /> credentials.
 
-1. Click the **Configure Mergin Maps Plugin** icon on the **Mergin Maps Toolbar**:
+1. Click the **Configure <MainPlatformNameNoLink /> Plugin** icon on the **<MainPlatformNameNoLink /> Toolbar**:
    ![](./qgis-configure-mergin-plugin.jpg)
 
 2. Enter your login credentials if these are blank
@@ -41,5 +41,5 @@ Upgrade the plugin periodically to ensure you can use the latest improvements.
 1. In QGIS, navigate to **Manage and Install Plugins...** in the **Plugins** tab
    ![](./qgis-plugins-manage-and-install.jpg)
    
-2. Find the **Mergin Maps** plugin. If there is a new version available, click **Upgrade Plugin**.
+2. Find the **<MainPlatformNameNoLink />** plugin. If there is a new version available, click **Upgrade Plugin**.
    ![upgrade plugin](./plugin-upgrade.png)

--- a/src/setup/sign-up-to-mergin-maps/index.md
+++ b/src/setup/sign-up-to-mergin-maps/index.md
@@ -1,9 +1,9 @@
 # How to Sign Up to Mergin Maps
 [[toc]]
 
-To start using the <MainPlatformName /> service, you need to sign up. You can sign up either through <MainDomainNameLink /> or from your mobile device using the <MobileAppName />.
+To start using the <MainPlatformNameLink /> service, you need to sign up. You can sign up either through <MainDomainNameLink /> or from your mobile device using the <MobileAppName />.
 
-When you register with <MainPlatformName />, you will be automatically signed up as a free tier user with 100 MB of storage. To upgrade your account, see our <MainDomainNameLink id="pricing" desc="Subscription plans" />.
+When you register with <MainPlatformNameLink />, you will be automatically signed up as a free tier user with 100 MB of storage. To upgrade your account, see our <MainDomainNameLink id="pricing" desc="Subscription plans" />.
 
 ::: tip
 One can view and download public projects even without an account, but creation of projects and synchronisation of geo-data only works when you are logged in.
@@ -22,7 +22,7 @@ One can view and download public projects even without an account, but creation 
 Check your spam folder if the confirmation email does not appear in your inbox after 5 minutes.
 :::
 
-**Welcome to <MainPlatformName />!**
+**Welcome to <MainPlatformNameLink />!**
 
 You can get up-to-speed quickly by following our [Quick Start tutorials](../../tutorials/capturing-first-data/index.md).
 
@@ -48,7 +48,7 @@ You can also sign up from <MobileAppName />.
 Check your spam folder if the confirmation email does not appear in your inbox after 5 minutes.
 :::
 
-**Welcome to <MainPlatformName />!**
+**Welcome to <MainPlatformNameLink />!**
 
 You can get up-to-speed quickly by following our [Quick Start tutorials](../../tutorials/capturing-first-data/index.md).
 

--- a/src/setup/sign-up-to-mergin-maps/index.md
+++ b/src/setup/sign-up-to-mergin-maps/index.md
@@ -1,9 +1,9 @@
 # How to Sign Up to Mergin Maps
 [[toc]]
 
-To start using the Mergin Maps service, you need to sign up. You can sign up either through <MainDomainNameLink /> or from your mobile device using the <MobileAppName />.
+To start using the <MainPlatformName /> service, you need to sign up. You can sign up either through <MainDomainNameLink /> or from your mobile device using the <MobileAppName />.
 
-When you register with the Mergin Maps service, you will be automatically signed up as a free tier user with 100 MB of storage. To upgrade your account, see our <MainDomainNameLink id="pricing" desc="Subscription plans" />.
+When you register with <MainPlatformName />, you will be automatically signed up as a free tier user with 100 MB of storage. To upgrade your account, see our <MainDomainNameLink id="pricing" desc="Subscription plans" />.
 
 ::: tip
 One can view and download public projects even without an account, but creation of projects and synchronisation of geo-data only works when you are logged in.
@@ -15,7 +15,7 @@ One can view and download public projects even without an account, but creation 
 2. Click on **Start for free**
    ![mergin maps register](./mergin-web-register.jpg)
 
-3. Create your account by filling up the form. Once you press **Sign up**, you will receive a confirmation email. To sign in and use the Mergin Maps service, you will need to activate your account by clicking on the link in the email.
+3. Create your account by filling up the form. Once you press **Sign up**, you will receive a confirmation email. To sign in and use  <MainPlatformName />, you will need to activate your account by clicking on the link in the email.
    ![sign up](./mergin-web-sign-up.png)
 
 ::: warning

--- a/src/setup/working-with-organisations/index.md
+++ b/src/setup/working-with-organisations/index.md
@@ -1,6 +1,6 @@
 # Working with Organisations
 
-In <MainPlatformName />, **Organisations** can be used for easier management of users and projects within your team.
+In <MainPlatformNameLink />, **Organisations** can be used for easier management of users and projects within your team.
 
 Just like ordinary user accounts, organisations can own and manage <MainPlatformName /> projects. All projects listed under an organisation use its  storage quota - rather than consuming storage quota of individual users that have created them.
 
@@ -35,7 +35,7 @@ Under profile you can:
 
 ## Inviting members
 
-To invite <MainPlatformName /> users to your new organisation:
+To invite <MainPlatformNameLink /> users to your new organisation:
 
 - From the left panel, under **Organisations** select your organisation to switch to your organisation profile
 - From the left panel, under **Settings** select **Members**

--- a/src/tutorials/creating-a-project-in-qgis/index.md
+++ b/src/tutorials/creating-a-project-in-qgis/index.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-In earlier tutorials you created a new survey project from within <MobileAppName />. That was a very fast (albeit limited) way of creating a <MainPlatformName /> project.
+In earlier tutorials you created a new survey project from within <MobileAppName />. That was a very fast (albeit limited) way of creating a <MainPlatformNameLink /> project.
 
 In this tutorial you will create a new project for surveying trees and hedges using QGIS.  
 
@@ -134,9 +134,9 @@ In the next tutorial we will see how this project looks on <MobileAppName />. We
    In a few moments your changes are safely stored in the cloud:
    ![synced](./qgis-project-synced.jpg)
 
-Synchronising changes between users and devices is a core principle of <MainPlatformName />. When you sync a project, changes that have been made by other users and devices since you last synced are fetched and any changes you've made are pushed.
+Synchronising changes between users and devices is a core principle of <MainPlatformNameLink />. When you sync a project, changes that have been made by other users and devices since you last synced are fetched and any changes you've made are pushed.
 
 Changes are merged safely and easily from different users, even when they edit the same feature. 
 
-<MainPlatformName /> tracks project version history so you can download a previous version of a project if you need to.
+<MainPlatformNameLink /> tracks project version history so you can download a previous version of a project if you need to.
 

--- a/src/tutorials/further-project-customisation/index.md
+++ b/src/tutorials/further-project-customisation/index.md
@@ -1,6 +1,6 @@
 # Further Project Customisation
 
-In this tutorial you will learn how to customise your <MainPlatformName /> project further, making it even more useful. The topics covered here are:
+In this tutorial you will learn how to customise your <MainPlatformNameLink /> project further, making it even more useful. The topics covered here are:
 
 [[toc]]
 

--- a/src/tutorials/mobile/index.md
+++ b/src/tutorials/mobile/index.md
@@ -6,7 +6,7 @@ In the last tutorial we created a new <MainPlatformName /> project in QGIS with 
 * Open the QGIS project in <MobileAppName />
 * Set GPS accuracy thresholds
 * Switch between layers to capture new point and linear features
-* Sync and save your data in <MainPlatformName /> cloud
+* Sync and save your data in <MainPlatformNameLink /> cloud
 
 :::tip
 Need help navigating <MobileAppName />? [<MobileAppName /> Interface](../../field/input_ui/) contains the overview of the functionality of the app's buttons and features.
@@ -121,7 +121,7 @@ When I surveyed my hedge, it was quite difficult to distinguish from the backgro
 We will learn how to change layer styles in the [next tutorial](../further-project-customisation/).
 
 ## Saving data to the cloud
-To conclude this tutorial we will push the data we just collected back to <MainPlatformName />.
+To conclude this tutorial we will push the data we just collected back to <MainPlatformNameLink />.
 1. Open the **Home** tab of the **Projects** page
 2. Press the sync button:
    ![](./merginmaps-mobile-sync-project.jpg)

--- a/src/tutorials/opening-surveyed-data-on-your-computer/index.md
+++ b/src/tutorials/opening-surveyed-data-on-your-computer/index.md
@@ -34,7 +34,7 @@ Now that your project is in the cloud, it can easily be shared with colleagues o
 ## Locating and opening your project
 1. Open QGIS on your computer
 2. [Install the <QGISPluginName />](../../setup/install-mergin-maps-plugin-for-qgis/index.md). 
-   You will use your <MainPlatformName /> credentials to configure the <QGISPluginName />.
+   You will use your <MainPlatformNameLink /> credentials to configure the <QGISPluginName />.
 3. Find the <MainPlatformName /> entry in the QGIS **Browser** panel:
 
    ![](./qgis-browser-panel.jpg)

--- a/src/tutorials/working-collaboratively/index.md
+++ b/src/tutorials/working-collaboratively/index.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-<MainPlatformName /> makes working collaboratively safe and easy.
+<MainPlatformNameLink /> makes working collaboratively safe and easy.
 
 In this tutorial you'll learn a few different ways of sharing your project with your colleagues.
 
@@ -11,7 +11,7 @@ In this tutorial you'll learn a few different ways of sharing your project with 
 1. Navigate to <MainDomainNameLink />.
 2. Click on **Go to my account** to sign in.
 
-   If you are new to <MainPlatformName />, click on **Start for free** and [sign up to <MainPlatformName />](../../setup/sign-up-to-mergin-maps/).
+   If you are new to <MainPlatformNameLink />, click on **Start for free** and [sign up to <MainPlatformName />](../../setup/sign-up-to-mergin-maps/).
 
    ![mergin maps register](./mergin-web-sign-in.jpg)
 
@@ -45,7 +45,7 @@ Jill should now have access to the project. This means they will be able to find
 ## Share a project with many users
 If you wish to share a project with more than a handful of users, this method may save you some time.
 
-These steps should be carried out from the <MainPlatformName /> dashboard.
+These steps should be carried out from the <AppDomainNameLink desc="Mergin Maps" /> dashboard.
 
 1. Click **My projects** then click ***trees-and-hedges***
    ![my project](./mergin-web-my-projects-trees-and-hedges.jpg)


### PR DESCRIPTION
New component `<MainPlatformNameLink />` created. It contains link to merginmaps.com (to point traffic to the main webpage).

`'<MainPlatformName />'` can be used for cases when it would be distracting to have too many hyperlinks in the text.

- [x]  go through the docs and check where it would be better to avoid having a hyperlink in the text