### PR TITLE
Note on EXIF tag names between exiftool and Android

### DIFF
--- a/src/layer/exif_metadata.md
+++ b/src/layer/exif_metadata.md
@@ -44,6 +44,8 @@ EXIF function supported by <MobileAppName />:
    - `GPSLongitude` returns GPS Longitude as rationals, e.g. 17/1, 6/1, 244907/10000.
    - `ImageWidth` returns the image width in pixels.
 
+**Important note about <EXIF_TAG_STRING>**: beware of what exiftool can output as tag names (ie. with `exiftool -n -S <PATH_TO_IMAGE>`). As explained in [exiftool documentation](https://exiftool.org/TagNames/EXIF.html), some tag names are displayed with names that can differ from the EXIF standard: `ImageWidth` is valid, but `ImageHeight` is not, you have to use the EXIF official name (`ImageLength`). Valid names are listed in the Android developer documentation for [ExifInterface](https://developer.android.com/reference/android/media/ExifInterface).
+
 ## Allowing location tags
 **Location tags have to be allowed** in the camera settings to store GPS EXIF metadata.
 

--- a/src/layer/exif_metadata.md
+++ b/src/layer/exif_metadata.md
@@ -44,7 +44,18 @@ EXIF function supported by <MobileAppName />:
    - `GPSLongitude` returns GPS Longitude as rationals, e.g. 17/1, 6/1, 244907/10000.
    - `ImageWidth` returns the image width in pixels.
 
-**Important note about <EXIF_TAG_STRING>**: beware of what exiftool can output as tag names (ie. with `exiftool -n -S <PATH_TO_IMAGE>`). As explained in [exiftool documentation](https://exiftool.org/TagNames/EXIF.html), some tag names are displayed with names that can differ from the EXIF standard: `ImageWidth` is valid, but `ImageHeight` is not, you have to use the EXIF official name (`ImageLength`). Valid names are listed in the Android developer documentation for [ExifInterface](https://developer.android.com/reference/android/media/ExifInterface).
+The list of **EXIF tags** can be found in the Android developer documentation for [ExifInterface](https://developer.android.com/reference/android/media/ExifInterface) or in [ExifTool documentation](https://exiftool.org/TagNames/EXIF.html). 
+
+Note that some of the tag names listed in [ExifTool documentation](https://exiftool.org/TagNames/EXIF.html) can differ from the EXIF specification. As an example, while `ImageWidth` tag is valid, `ImageHeight` is not and you have to use `ImageLength` tag name (defined by EXIF specification) when [recording EXIF metadata](#how-to-use-exif-metadata) in <MobileAppName />.
+
+:::details
+EXIF tags that can be retrieved from your images can vary depending on how they were created (e.g. what type of device you used to capture photos). EXIF tags that are recorded in your image can be displayed, e.g., using [ExifTool](https://exiftool.org/):
+```
+exiftool -n -S <PATH_TO_IMAGE>
+```
+
+However, keep in mind that the EXIF tag names that you get from ExifTool can differ from EXIF specification. To store EXIF metadata using <MainPlatformNameLink />, you have to use the latter.
+:::
 
 ## Allowing location tags
 **Location tags have to be allowed** in the camera settings to store GPS EXIF metadata.


### PR DESCRIPTION
It took me a while to figure out why `read_exif(@project_home + '/pictures/' +  "Picture", 'ImageWidth')` was working, whereas `read_exif(@project_home + '/pictures/' +  "Picture", 'ImageHeight')` was not... I hope this note can help others!