### PR TITLE
Cleanup domain name for fs HostOnly cookies

### DIFF
--- a/src/.vuepress/components/cookie-consent/cookie.js
+++ b/src/.vuepress/components/cookie-consent/cookie.js
@@ -11,15 +11,12 @@ export default class Coookie {
    * Finsweet merginmaps.com is not able to write cookies to .merginmaps.com, because they have own merginmaps.com cookie.
    * Prirority is .merginmaps.com, so users options are not sharing between subdomains.
    *
-   * Best solution is to use window.location.hostname.
+   * Best solution is to use window.location.hostname or no domain HostOnly=true cookies.
    * */
   domainName = ''
 
   constructor(cookieConsentName) {
     this.cookieConsentName = cookieConsentName || this.cookieConsentName
-    if (typeof window === 'object') {
-      this.domainName = window.location.hostname
-    }
   }
 
   _getByName(name) {


### PR DESCRIPTION
Finsweet is adding HostOnly cookies without leading dot. If domain in cookies is specified in production evnironments (no localhost), domain is automatically added with leading dot. 