### PR TITLE
fix #100 link relevant articles

### DIFF
--- a/src/layer/attach-multiple-photos-to-features/index.md
+++ b/src/layer/attach-multiple-photos-to-features/index.md
@@ -1,7 +1,10 @@
 # How to Attach Multiple Photos to Features
 
+In some situations, it might be useful to take more than one picture of a feature during the field survey. Attaching multiple photos to one feature is a 1-N relation. You can read more about 1-N relations and how they can be used in <MainPlatformNameLink /> in [How to link multiple records to one feature](./one-to-n-relations/).
+
 :::tip
-To see this setup in practice, clone the following project: <MerginMapsProject id="documentation/forms_multiple_photos" />.
+To see this setup in practice, you can download the following project: 
+<MerginMapsProject id="documentation/forms_multiple_photos" />.
 :::
 
 To link multiple photos to a single feature, we need a **unique field** to link following tables:

--- a/src/layer/attach-multiple-photos-to-features/index.md
+++ b/src/layer/attach-multiple-photos-to-features/index.md
@@ -1,6 +1,6 @@
 # How to Attach Multiple Photos to Features
 
-In some situations, it might be useful to take more than one picture of a feature during the field survey. Attaching multiple photos to one feature is a 1-N relation. You can read more about 1-N relations and how they can be used in <MainPlatformNameLink /> in [How to link multiple records to one feature](./one-to-n-relations/).
+In some situations, it might be useful to take more than one picture of a feature during the field survey. Attaching multiple photos to one feature is a 1-N relation. You can read more about 1-N relations and how they can be used in <MainPlatformNameLink /> in [How to link multiple records to one feature](../one-to-n-relations/).
 
 :::tip
 To see this setup in practice, you can download the following project: 

--- a/src/layer/plugin-variables.md
+++ b/src/layer/plugin-variables.md
@@ -1,6 +1,6 @@
 # Extra QGIS Variables
 
-The plugin adds several variables that can be used in QGIS expressions:
+The <QGISPluginName /> adds several variables that can be used in QGIS expressions:
 
 | Variable name               | Sample value                     | Scope   | Description |
 |-----------------------------|----------------------------------|---------|-------------|
@@ -11,4 +11,4 @@ The plugin adds several variables that can be used in QGIS expressions:
 | `@mergin_project_full_name` | `martin/Tree survey`             | project | Owner and project name joined with a forward slash |
 | `@mergin_project_version`   | `42`                             | project | Current version of the active project |
 
-A common use case is to use `@mergin_username` as the default value for one of the fields in a survey layer to automatically track who has added (and/or modified) a particular record.
+A common use case is to use `@mergin_username` as the [default value](./settingup_forms_settings/#default-values) for one of the fields in a survey layer to automatically track who has added (and/or modified) a particular record.

--- a/src/layer/position_variables.md
+++ b/src/layer/position_variables.md
@@ -1,8 +1,8 @@
 # Extra Position Variables
 
-<MobileAppName /> provides the option to access GPS information using an extra position variables. Note that location permission have to be allowed and location service has to be enabled.
+With <MobileAppName />, it is possible to access GPS information using extra position variables. Note that location permission has to be allowed and location service enabled.
 
-Extra position variables can be used as [default values in feature forms](./settingup_forms_settings/#default-values). 
+Extra position variables can be used as [default values in feature forms](./settingup_forms_settings/#default-values).
 
 Following variables are supported:
  - `@position_coordinate` - A point with the coordinates in WGS84.

--- a/src/layer/settingup_forms_photo.md
+++ b/src/layer/settingup_forms_photo.md
@@ -1,7 +1,13 @@
 # Capturing Photos
-[[toc]]
 
 When surveying, you might want to take a photo from your camera or attach an existing photo from the device gallery to your survey feature.
+
+Here, you will find the overview of the basic functionality related to capturing photos, such as:
+[[toc]]
+
+:::tip
+Do you need to attach multiple pictures to one feature? [How to attach multiple photos to features](./attach-multiple-photos-to-features/) will guide you through the setup.
+:::
 
 ## Attachment widget in QGIS
 

--- a/src/misc/write-docs/index.md
+++ b/src/misc/write-docs/index.md
@@ -114,6 +114,8 @@ In each section in the menu (except Getting Started and Guides):
 - following with a bunch of how to articles
 - ending with reference documentation pages
 
+References to other articles, blog posts or resources should be linked where relevant, either as [tips](#tip-warning-info-error-note-box) or as *Further reading* sections.
+
 ### Users & Workspaces
 
 - To store all projects referenced in the documentation use <MainPlatformName /> workspace `documentation`


### PR DESCRIPTION
fix #100 Instruction to link relevant articles added to the write-docs as this is something that should be done when possible/appropriate (and I try to do it when updating docs :) )
- link to How to attach multiple photos added to the Capturing Photos page