### PR TITLE
Ellipsoid / orthometric heights returned by internal / external GNSS …

### DIFF
--- a/scripts/wordlist.txt
+++ b/scripts/wordlist.txt
@@ -78,6 +78,7 @@ Multiline
 nginx
 NDK
 OneDrive
+orthometric
 NMEA
 NTRIP
 OSGB

--- a/src/field/input_ui.md
+++ b/src/field/input_ui.md
@@ -57,6 +57,10 @@ Tapping the GPS accuracy tab opens the GPS info panel:
 - **Speed**
 - **Last fix**: time of the last received GPS position
 
+::: tip
+External GNSS devices return orthometric heights (ellipsoid with the geoid separation applied)
+:::
+
 ![GPS info panel](./input-gps-info.jpg "GPS info panel") 
 
 ## Record


### PR DESCRIPTION
…devices

Ellipsoid height is returned by internal GPS receivers. External GNSS devices usually apply the geoid separation and return orthometric height.

Please see https://github.com/MerginMaps/input/issues/2615 - we could have the separation as an optional variable, so users can calculate ellipsoid height if they need it.