### PR TITLE
rename mobile since badge

### DIFF
--- a/src/.vuepress/components/SinceBadge.vue
+++ b/src/.vuepress/components/SinceBadge.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-  <span class="sincebadge" v-if="type === 'App'" >since Input App {{ version }}</span>
+  <span class="sincebadge" v-if="type === 'App'" >since Mobile {{ version }}</span>
   <span class="sincebadge" v-else-if="type === 'Plugin'">since Plugin {{ version }}</span>
   <span class="sincebadge" v-else-if="type === 'Server'">since Server {{ version }}</span>
   </span>


### PR DESCRIPTION
fix #335 since badge renamed from Input App to Mobile
This is how all badges look now:
![image](https://github.com/MerginMaps/docs/assets/94905350/2656d819-248f-4728-8f7b-174ccf7f7f08)

This is how it looks in docs:
![image](https://github.com/MerginMaps/docs/assets/94905350/58ec9e75-579f-4688-999a-8ec0194bfd56)
