### PR TITLE
Iss #324 ellipsoid and orthometric altitude

### DIFF
--- a/src/field/external_gps.md
+++ b/src/field/external_gps.md
@@ -8,6 +8,8 @@ External GPS receivers can be connected to your mobile device via Bluetooth and 
 
 There are several [extra position variables](../layer/position_variables/) that can be useful to record when doing the survey with external GPS, such as the GPS antenna height, GPS device name as well as metrics like horizontal, vertical or position dilution of precision (HDOP, VDOP, PDOP).
 
+Note that external GPS devices usually return orthometric heights (ellipsoid with the geoid separation applied).
+
 **Before you start**:
 - Set up your device according to the instructions of its manufacturer. You should continue only when you are sure that the device is working and sending data.
 - Make sure that your mobile device offers the functionality to pair with an external GPS device and that it communicates through a standard interface.

--- a/src/field/gps_accuracy.md
+++ b/src/field/gps_accuracy.md
@@ -10,7 +10,7 @@ When doing the survey, it is essential to be aware of the limitations of your GP
 A warning will appear, if your accuracy is outside the GPS accuracy threshold. To get rid of this warning, you can increase your **Accuracy threshold** or turn off these warnings in [Settings](./input_ui.md#gps-settings).
 ![Low GPS position accuracy warning](./input-gps-warning.jpg "Low GPS position accuracy warning")
 
-Tapping the GPS accuracy tab opens the GPS info panel, which contains information about the horizontal and vertical accuracy, as well as number of satellites in use.
+Tapping the GPS accuracy tab opens the [GPS info panel](./input_ui/#gps), which contains information about the horizontal and vertical accuracy, as well as number of satellites in use.
 ![GPS info panel](./input-gps-info.jpg "GPS info panel")
 
 If you'd like to have higher accuracy, you can wait for your device to acquire a better GPS signal. For precise measurements, you may need to connect your device to an [external GPS](./external_gps.md).

--- a/src/field/input_ui.md
+++ b/src/field/input_ui.md
@@ -52,14 +52,10 @@ Tapping the GPS accuracy tab opens the GPS info panel:
 - **Longitude, Latitude**: current position
 - **X, Y**: current position in project's coordinate reference system
 - **Horizontal** and **Vertical accuracy** of the GPS position
-- **Altitude**: ellipsoidal height
+- **Altitude**: ellipsoidal height if internal GPS is used. [External GPS](./external_gps/) devices usually return orthometric heights (ellipsoid with the geoid separation applied).
 - **Satellites (in use/view)**: number of satellites
 - **Speed**
 - **Last fix**: time of the last received GPS position
-
-::: tip
-External GNSS devices return orthometric heights (ellipsoid with the geoid separation applied)
-:::
 
 ![GPS info panel](./input-gps-info.jpg "GPS info panel") 
 


### PR DESCRIPTION
fix #324 
- info about orthometric heights added to [External GPS](https://merginmaps.com/docs/field/external_gps/)  
- in [MM Input Interface](https://merginmaps.com/docs/field/input_ui/) , type of heights added for internal/external GPS (it is not highlighted as a tip as I feel like it's interesting only for a relatively small user group)