### PR TITLE
add banner for non-english versions

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -31,7 +31,8 @@ module.exports = {
     ['meta', { name: 'theme-color', content: '#004C45' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
     ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
-    ['link', { rel: 'icon', href: '/favicon.ico' }]
+    ['link', { rel: 'icon', href: '/favicon.ico' }],
+    ['script', { type: 'text/javascript', src: 'https://cdn.weglot.com/weglot.min.js'}],
   ],
   locales: {
     '/': {

--- a/src/.vuepress/enhanceApp.js
+++ b/src/.vuepress/enhanceApp.js
@@ -27,4 +27,6 @@ export default ({
     },
     router
   )
+  /** Customized api key for weglot */
+  Vue.prototype.$weglotApiKey = "wg_793fda6a46586055f8d5df5cc9fa6a270"
 }

--- a/src/.vuepress/theme/components/PageHeader.vue
+++ b/src/.vuepress/theme/components/PageHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="showHeader" class="page-header">
     <p>
-      This document is machine translated,<br />read <a :href="url">original</a> version.
+      This document is machine translated, see <a :href="url">original</a> version.
     </p>
   </div>
 </template>

--- a/src/.vuepress/theme/components/PageHeader.vue
+++ b/src/.vuepress/theme/components/PageHeader.vue
@@ -14,9 +14,13 @@ export default Vue.extend({
   components: {},
   data: function () {
     return {
-      url: "https://merginmaps.com" + window.location.pathname,
-      showHeader: ['localhost', 'www.merginmaps.com', 'merginmaps.com'].includes(window.location.hostname)
+      url: null,
+      showHeader: false
     }
+  },
+  mounted() {
+    this.url = "https://merginmaps.com" + window.location.pathname
+    this.showHeader = ['localhost', 'www.merginmaps.com', 'merginmaps.com'].includes(window.location.hostname)
   }
 });
 </script>

--- a/src/.vuepress/theme/components/PageHeader.vue
+++ b/src/.vuepress/theme/components/PageHeader.vue
@@ -1,7 +1,11 @@
 <template>
-  <div v-if="showHeader" class="page-header">
+  <div
+    :style="pageHeaderStyle"
+    class="page-header"
+  >
     <p>
-      This document is machine translated, see <a :href="url">original</a> version.
+      This document is machine translated, see
+      <a :href="'#'" @click.prevent="switchLang('en')">original</a> version.
     </p>
   </div>
 </template>
@@ -14,20 +18,58 @@ export default Vue.extend({
   components: {},
   data: function () {
     return {
-      url: null,
-      showHeader: false
-    }
+      showHeader: false,
+      currentLang: null,
+    };
   },
   mounted() {
-    this.url = "https://merginmaps.com" + window.location.pathname
-    this.showHeader = ['localhost', 'www.merginmaps.com', 'merginmaps.com'].includes(window.location.hostname)
-  }
+    Weglot.initialize({
+      api_key: this.$weglotApiKey,
+      auto_switch: false,
+      hide_switcher: true,
+    });
+
+    Weglot.on("initialized", () => {
+      this.currentLang = Weglot.getCurrentLang();
+    });
+
+    Weglot.on("languageChanged", () => {
+      this.currentLang = Weglot.getCurrentLang();
+    });
+  },
+  computed: {
+    pageHeaderStyle() {
+      if (this.showHeader) {
+        return {
+          marginBottom: 'initial',
+          visibility: "visible",
+        }
+      }
+      return {
+        marginBottom: "-6rem",
+        visibility: "hidden",
+      };
+    }
+  },
+  methods: {
+    switchLang(lang) {
+      Weglot.switchTo(lang);
+    },
+  },
+  watch: {
+    currentLang: {
+      immediate: true,
+      handler(newLang) {
+        this.showHeader = newLang && newLang !== "en";
+      },
+    },
+  },
 });
 </script>
 
 <style lang="scss" scoped>
 .page-header {
-  padding: .1rem 1.5rem;
+  padding: 0.1rem 1.5rem;
   background-color: #f3f5f7;
   font-size: 0.9rem;
   align-items: center;

--- a/src/.vuepress/theme/components/PageHeader.vue
+++ b/src/.vuepress/theme/components/PageHeader.vue
@@ -1,0 +1,31 @@
+<template>
+  <div v-if="showHeader" class="page-header">
+    <p>
+      This document is machine translated,<br />read <a :href="url">original</a> version.
+    </p>
+  </div>
+</template>
+
+<script>
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "PageHeader",
+  components: {},
+  data: function () {
+    return {
+      url: "https://merginmaps.com" + window.location.pathname,
+      showHeader: ['localhost', 'www.merginmaps.com', 'merginmaps.com'].includes(window.location.hostname)
+    }
+  }
+});
+</script>
+
+<style lang="scss" scoped>
+.page-header {
+  padding: .1rem 1.5rem;
+  background-color: #f3f5f7;
+  font-size: 0.9rem;
+  align-items: center;
+}
+</style>

--- a/src/.vuepress/theme/layouts/Layout.vue
+++ b/src/.vuepress/theme/layouts/Layout.vue
@@ -1,19 +1,22 @@
 <template>
   <div>
-    <ParentLayout
-      ><template #page-bottom><PageFooter /></template></ParentLayout
-    >
+    <ParentLayout>
+       <template #sidebar-top><PageHeader /></template> 
+       <template #page-bottom><PageFooter /></template>
+    </ParentLayout>
   </div>
 </template>
 
 <script>
 import PageFooter from "@theme/components/PageFooter.vue";
+import PageHeader from "@theme/components/PageHeader.vue";
 import ParentLayout from "@parent-theme/layouts/Layout.vue";
 
 export default {
   components: {
     ParentLayout,
-    PageFooter
+    PageFooter,
+    PageHeader
   },
 };
 </script>


### PR DESCRIPTION
We want to try to use Weglot for machine translations of the docs, we place small text for language mutations (e.g. on `de.merginmaps.com/docs`

fix https://github.com/MerginMaps/docs/issues/133

![Screenshot 2023-11-02 at 16 31 02](https://github.com/MerginMaps/docs/assets/804608/0a5a8e03-8ac5-48a4-9cf9-a59446de1327)

cc @janpaulovic1 @mostlyAtNight 