### PR TITLE
#462 titles clean up: forms > attributes form

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -18,11 +18,11 @@ The ecosystem consist of various components:
  - <AppDomainNameLink desc="Mergin Maps Server" /> > SaaS Cloud Service (available also as <MainPlatformName /> CE)
  - <MainDomainNameLink desc="Mergin Maps mobile app" /> > iOS and Android mobile app
 
+<AppDownload />
+
 <YouTube id="dy-B1BW9lA0" />
  
 ## Get started 
-
-<AppDownload />
 
 - [Capturing Your First Field Data](./tutorials/capturing-first-data/index.md)
 - [Opening Surveyed Data on Your Computer](./tutorials/opening-surveyed-data-on-your-computer/index.md)
@@ -67,17 +67,17 @@ The ecosystem consist of various components:
 
 ## Configure Survey Layer
 - [Best Practice Tips for Layers and Forms](./layer/best-practice/)
-- [Setting Up Form Widgets](./layer/settingup_forms/)
-- [Advanced Form Configuration](./layer/settingup_forms_settings/)
-- [Form Layout](./layer/settingup_forms_settings/)
+- [Setting Up Widgets in Attributes Form](./layer/settingup_forms/)
+- [Attributes Form Configuration](./layer/settingup_forms_settings/)
+- [Attributes Form Layout](./layer/settingup_forms_settings/)
 - [Exif Metadata](./layer/exif_metadata/)
 - [Capturing Photos](./layer/settingup_forms_photo/)
 - [How to Attach Multiple Photos to Features](./layer/attach-multiple-photos-to-features/)
 - [How to Link Multiple Records to One Feature (1-N Relations)](./layer/one-to-n-relations/)
 - [How to Use Hyperlinks](./layer/external-link/)
+- [Working with Non-spatial Tables](./layer/working_with_nonspatial_data/)
 - [Extra Position Variables](./layer/position_variables/)
 - [Extra QGIS Variables](./layer/plugin-variables/)
-- [Working with Non-spatial Tables](./layer/working_with_nonspatial_data/)
 
 ## Fieldwork Tips
 - [<MobileAppName /> Interface](./field/mobile-app-ui/)
@@ -102,13 +102,13 @@ The ecosystem consist of various components:
 
 ## Custom Server
 - [Overview](./server/)
-- [How to Install](./server/install/)
-- [How to Upgrade](./server/upgrade/)
+- [Install](./server/install/)
+- [Upgrade](./server/upgrade/)
 - [Administer](./server/administer/)
-- [Troubleshoot](./server/troubleshoot/)
+- [Troubleshoot Custom Servers](./server/troubleshoot/)
 
 ## Migrate
-- [From QField and QFieldCloud](./migrate/qfield/)
+- [From QField](./migrate/qfield/)
 
 ## Support & Legal
 - [Licensing](./misc/licensing/)

--- a/src/layer/form-layout/index.md
+++ b/src/layer/form-layout/index.md
@@ -1,4 +1,4 @@
-# Form Layout
+# Attributes Form Layout
 [[toc]]
 
 Collecting and editing data in the field can be more efficient with forms that are easy to navigate. QGIS offers a lot of options for improving the layout of your forms, such as using groups and tabs to keep related fields together, displaying or hiding a group of fields based on conditional visibility, or displaying tips and instructions in the forms.

--- a/src/layer/settingup_forms.md
+++ b/src/layer/settingup_forms.md
@@ -1,4 +1,4 @@
-# Setting Up Form Widgets
+# Setting Up Widgets in Attributes Form
 
 [[toc]]
 
@@ -6,15 +6,15 @@
 Our mobile app was redesigned. We are in the process of updating this content to reflect these changes.
 :::
 
-Capturing field data often requires filling some attributes in the form to record the properties of surveyed points, lines or polygons. Forms can simplify the data entry and even ensure to some extent that the correct information is filled in.
+Capturing field data often requires filling some attributes in the form to record the properties of surveyed points, lines or polygons. Attributes forms can simplify the data entry and even ensure to some extent that the correct information is filled in.
 
 <YouTube id="jc4p1PpXj3k" />
 
 ## Widget gallery
 
-A number of edit widget types for forms can be used in <MobileAppName />, including drop-down options, slider, date and time, checkbox, or photos. 
+A number of edit widget types for attributes form can be used in <MobileAppName />, including drop-down options, slider, date and time, checkbox, or photos. 
 
-Forms can be configured using <QGISHelp ver="latest" link="user_manual/working_with_vector/vector_properties.html#edit-widgets" text="QGIS widget types" /> .
+Attributes forms can be configured using <QGISHelp ver="latest" link="user_manual/working_with_vector/vector_properties.html#edit-widgets" text="QGIS widget types" /> .
 
 |QGIS widget  | Description  |<div style="width:300px">Preview in <MobileAppName /> </div> |Example project   |
 |:---:|:---:|:---:|:---:|
@@ -29,7 +29,7 @@ Forms can be configured using <QGISHelp ver="latest" link="user_manual/working_w
 |Value Relation   |[Drop-down menu with values from another table](#value-relation) |![Mergin Maps mobile app value relation field form](./input_forms_valuerelation.jpg "Mergin Maps mobile app value relation field form")   | <MerginMapsProjectShort id="documentation/test_forms" /> |
 
 :::tip
-Extra configuration can be done to the form layout to make the data collection easier and more consistent, such as using default values, conditional visibility or constraint enforcement. See [Advanced Form Configuration](./settingup_forms_settings/) for more details.
+Extra configuration can be done to make the data collection easier and more consistent, such as using default values, conditional visibility or constraint enforcement. See [Advanced Form Configuration](./settingup_forms_settings/) for more details.
 :::
 
 ## Text

--- a/src/layer/settingup_forms_settings.md
+++ b/src/layer/settingup_forms_settings.md
@@ -1,4 +1,4 @@
-# Advanced Form Configuration
+# Attributes Form Configuration
 [[toc]]
 
 ::: warning

--- a/src/server/troubleshoot/index.md
+++ b/src/server/troubleshoot/index.md
@@ -1,4 +1,4 @@
-# Troubleshoot custom servers
+# Troubleshoot Custom Servers
 
 This article will help you debug and resolve issues in your <CommunityPlatformNameLink /> or <EnterprisePlatformNameLink /> deployment. If you use the main SaaS <DashboardLink desc="Mergin Maps Server"/>, it is always up-to-date and managed by <MainPlatformName /> team, so report your problems to us as [described here](../../misc/troubleshoot/index.md). Read more about server platforms in [overview article](../index.md).
 


### PR DESCRIPTION
fix #462
Renamed titles of pages that describe working with attributes forms to use the correct terminology (forms > attributes form):
- [Setting Up Form Widgets](https://merginmaps.com/docs/layer/settingup_forms/) - renamed to: **Setting Up Widgets in Attributes Form**
- [Advanced Form Configuration](https://merginmaps.com/docs/layer/settingup_forms_settings/) - renamed to: **Attributes Form Configuration**
- [Form Layout](https://merginmaps.com/docs/layer/form-layout/) - renamed to: **Attributes Form Layout**

+ fixing headlines in the list on the landing page so they match the pages
