### PR TITLE
Smartloook integration init

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vuepress-plugin-fulltext-search": "^2.2.1"
   },
   "dependencies": {
-    "@gtm-support/vue2-gtm": "1.0.0"
+    "@gtm-support/vue2-gtm": "1.0.0",
+    "smartlook-client": "^10.0.0"
   }
 }

--- a/src/.vuepress/components/CookieConsentView.vue
+++ b/src/.vuepress/components/CookieConsentView.vue
@@ -17,6 +17,7 @@
 
 <script lang="ts">
 import Vue from "vue";
+import Smartlook from "smartlook-client";
 
 import CookieConsentBanner from "./cookie-consent/components/CookieConsentBanner.vue";
 import CookieConsentPreferences from "./cookie-consent/components/CookieConsentPreferences.vue";
@@ -83,6 +84,12 @@ export default Vue.extend({
       immediate: true,
       handler: function (value) {
         this.$gtm && this.$gtm.enable(value);
+        const smartlookKey = __SMARTLOOK_KEY__
+        if (value && smartlookKey && !Smartlook.initialized()) {
+          Smartlook.init(__SMARTLOOK_KEY__, {
+            region: 'eu'
+          })
+        }
       },
     },
   },

--- a/src/.vuepress/components/CookieConsentView.vue
+++ b/src/.vuepress/components/CookieConsentView.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
         this.$gtm && this.$gtm.enable(value);
         const smartlookKey = __SMARTLOOK_KEY__
         if (value && smartlookKey && !Smartlook.initialized()) {
-          Smartlook.init(__SMARTLOOK_KEY__, {
+          Smartlook.init(smartlookKey, {
             region: 'eu'
           })
         }

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -104,5 +104,9 @@ module.exports = {
 
   globalUIComponents: [
     'CookieConsentView'
-  ]
+  ],
+
+  define: {
+    __SMARTLOOK_KEY__: 'a42250fed50d7af2a9630117644ec5ac4b9c419f'
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7331,6 +7331,11 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
+smartlook-client@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/smartlook-client/-/smartlook-client-10.0.0.tgz#8c322bfa5866f5d9c1553c22aa98382367f798bd"
+  integrity sha512-KAyy+MXxgqfQJOqsnJhlFiBP29g7rE50hmdoSB3YYq15Dl9y8WEdh1OhdUAYWnENkyDHu3v5lE39O6VuhQMgrA==
+
 smoothscroll-polyfill@^0.4.3:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"


### PR DESCRIPTION
- map to smartlook account

:exclamation: 

- we could introduce env files for Gtm / smartlook keys, but I'm not sure if it's important before migration to vitepress.