### PR TITLE
GeoPDF to geospatial pdf

### DIFF
--- a/src/gis/supported_formats.md
+++ b/src/gis/supported_formats.md
@@ -43,7 +43,7 @@ To use a *Connection Service File*, you have to:
 | PNG            | :thumbsup:        |                                                                                                           |
 | COG (local)    | :thumbsup:        |                                                                                                           |
 | MBTiles        | :thumbsup:        | png, jpg compression                                                                                      |
-| GeoPDF         | :thumbsup:        |                                                                                                           |
+| Geospatial PDF | :thumbsup:        |                                                                                                           |
 | WM(T)S         | :thumbsup:        | requires internet connection                                                                              |
 | XYZ tiles      | :thumbsup:        | requires internet connection (e.g. OpenStreetMap)                                                         |
 | COG (online)   | :thumbsup:   | requires internet connection |

--- a/src/gis/supported_formats.md
+++ b/src/gis/supported_formats.md
@@ -43,7 +43,7 @@ To use a *Connection Service File*, you have to:
 | PNG            | :thumbsup:        |                                                                                                           |
 | COG (local)    | :thumbsup:        |                                                                                                           |
 | MBTiles        | :thumbsup:        | png, jpg compression                                                                                      |
-| Geospatial PDF | :thumbsup:        |                                                                                                           |
+| <NoSpellcheck id="Geospatial" /> PDF | :thumbsup:        |                                                                                                           |
 | WM(T)S         | :thumbsup:        | requires internet connection                                                                              |
 | XYZ tiles      | :thumbsup:        | requires internet connection (e.g. OpenStreetMap)                                                         |
 | COG (online)   | :thumbsup:   | requires internet connection |


### PR DESCRIPTION
Changing GeoPDF to Geospatial PDF in [Supported Formats](https://merginmaps.com/docs/gis/supported_formats/) to avoid the trademarked term.