### PR TITLE
Clarify proxy.user chown command

### DIFF
--- a/src/server/install/index.md
+++ b/src/server/install/index.md
@@ -39,7 +39,7 @@ Once configured, you can run:
 ```shell
 $ mkdir -p projects # or wherever you set it to be
 $ mkdir -p mergin_db # or wherever you set it to be
-$ sudo chown -R  901:999 ./projects/
+$ sudo chown -R  901:999 ./projects/ # the number for the user (e.g. 901:999) should match that defined in the docker-compose.yml file (proxy.user)  
 $ sudo chmod g+s ./projects/
 $ docker-compose -f docker-compose.yml up
 ```


### PR DESCRIPTION
In the chown command, the number the user (e.g. 901:999) should match that defined in the docker-compose.yml file (proxy.user).

If they don't match, it results in an error in starting the proxy server component.

As of most recent commit 74a716f8932a2233c942f5bca98b1b76ec2e7875 on master branch, the [proxy.user in docker-compose.yml](https://github.com/MerginMaps/server/blob/74a716f8932a2233c942f5bca98b1b76ec2e7875/docker-compose.yml#L92) specifies 101:999, which is different than this documentation.