### PR TITLE
minimum OS versions for mobile app

### DIFF
--- a/src/misc/troubleshoot/index.md
+++ b/src/misc/troubleshoot/index.md
@@ -6,6 +6,7 @@ Did you encounter an issue when using <MainPlatformNameLink />? Here are some tr
 - Do you have enough storage? Check your [subscription and data usage](../../manage/dashboard/#subscriptions).
 - Are you missing some data after synchronisation? [How to Recover Missing Data](../../manage/missing-data/) will show you how to deal with [**conflict files**](../../manage/missing-data/#there-are-conflict-files-in-the-folder) and how to [**manually download**](../../manage/missing-data/#there-are-no-conflict-files-in-the-folder) data from your mobile device.
 - Modifying data schema of survey layers is a common source of synchronisation issues. [How to Deploy Revised Projects](../../manage/missing-data/) will instruct you how to do it correctly.
+- Unable to install or update <MobileAppName />? Check the [OS version](#minimum-os-versions-for-mergin-maps-mobile-app) of your mobile device. 
 - If <MobileAppName /> cannot open your project or form, see [How to Fix a Broken Project](../../field/broken-project/).
 - If <MobileAppName /> displays **PROJ error**, see [Custom Projections](../../gis/proj/).
 - For troubleshooting custom server deployments, look at [this dedicated page](../../server/troubleshoot/).
@@ -34,6 +35,15 @@ If you have an active <MainPlatformNameLink /> subscription or during the trial 
 - Join our [community chat on Slack](https://merginmaps.com/community/join) and ask questions!
 - See [GIS Stack Exchange](https://gis.stackexchange.com/questions/tagged/mergin-maps) with "<NoSpellcheck id="mergin-maps" />" tag to ask questions and see other users' answers.
 - See <QGISHelp ver="3.22" link="user_manual/index.html" text="QGIS documentation" /> for QGIS Desktop related problems.
+
+## Minimum OS versions for Mergin Maps mobile app
+
+The <MobileAppNameShort /> currently supports following OS versions:
+- **Android 9** or above
+- **iOS 16** or above
+- Windows 10 or Windows 11
+
+If your mobile device uses an older version of OS, you may be unable to install or update the <MobileAppNameShort />.
 
 ## How to share your project with Mergin Maps support
 

--- a/src/setup/install-mobile-app/index.md
+++ b/src/setup/install-mobile-app/index.md
@@ -7,6 +7,10 @@ Download <MobileAppName /> to your Android device, iPhone or iPad. You can find 
 
 <AppDownload></AppDownload>
 
+::: tip Supported OS versions
+The minimum OS versions requirements for the <MobileAppNameShort /> are **Android 9** and **iOS 16**.
+:::
+
 You can use the <MobileAppNameShort /> without having a <MainPlatformName /> account. Our [Capturing Your First Field Data](../../tutorials/capturing-first-data/) tutorial will show you how to create a project and capture your first data in the field.
 
 However, to make full use of <MainPlatformNameLink />, we recommend you [signing up to Mergin Maps](../sign-up-to-mergin-maps/). When sign in, you can use <DashboardLink /> to, e.g., manage your projects and share them with other users, or use our <QGISPluginNameShort /> to get your data and projects to <QGIS link="en/site/forusers/download.html" text="QGIS" />.
@@ -20,5 +24,5 @@ These tutorials cover all the basics from capturing data in the field, opening t
 ## Mergin Maps mobile app on Windows
 If you want to use the <MobileAppNameShort /> on Windows, you need to download the <NoSpellcheck id=".exe" /> installer from <GitHubRepo id="MerginMaps/mobile/releases/latest" desc="MerginMaps/mobile" /> repository and install it on your computer.
 
-
+The <MobileAppNameShort /> requires using Windows 10 or Windows 11. 
 


### PR DESCRIPTION
fix #620 
Info about the minimum OS versions for mobile app added to:
- [How to Install Mergin Maps Mobile App ](https://merginmaps.com/docs/setup/install-mobile-app/)
- [Troubleshoot](https://merginmaps.com/docs/misc/troubleshoot/)