### PR TITLE
Permissions - edit workspace description and closing the workspace

### DIFF
--- a/src/manage/permissions/index.md
+++ b/src/manage/permissions/index.md
@@ -47,6 +47,7 @@ This is the overview of workspace member roles that are related to the whole wor
 |delete and transfer projects| :no_entry_sign: | :no_entry_sign:  | :no_entry_sign:  | :white_check_mark: | :white_check_mark: |
 |manage access to projects| :no_entry_sign: | :no_entry_sign: | :no_entry_sign:  | :white_check_mark: | :white_check_mark: |
 |manage workspace members| :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: | :white_check_mark: |
+|delete the workspace and change its description| :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: |
 |access to invoicing and subscription settings| :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :no_entry_sign: | :white_check_mark: |
 
 

--- a/src/manage/workspaces/index.md
+++ b/src/manage/workspaces/index.md
@@ -95,6 +95,8 @@ Every workspace has its own [subscription](../subscriptions/). With your first w
 ## How to delete a workspace
 Closing a workspace means that all projects in this workspace will be removed as well. Therefore we recommend going through the projects in the workspace and, if needed, downloading them to your computer or [transferring them to another workspace](../project-advanced/#transfer-a-project) so that you don't lose your work.
 
+You have to be the workspace [owner](../permissions/#workspace-member-roles-overview) to be able to delete the workspace.
+
 1. [Switch](#how-to-switch-between-workspaces) to the workspace you want to remove
 
 2. Navigate to **Settings** and select **Close workspace**


### PR DESCRIPTION
Added info that only owners can delete the workspace and change its description to [Workspace member roles overview](https://merginmaps.com/docs/manage/permissions/#workspace-member-roles-overview)