### PR TITLE
missing server command

### DIFF
--- a/src/server/install/index.md
+++ b/src/server/install/index.md
@@ -125,7 +125,7 @@ Celery running properly
 To test email configuration:
 
 ```shell
-$ docker exec merginmaps-server flask send-check-email --email me@myorg.com
+$ docker exec merginmaps-server flask server send-check-email --email me@myorg.com
 ```
 
 By default, email notifications are disabled, so output will be similar to this:


### PR DESCRIPTION
The email test command is now under `server` group of commands