### PR TITLE
Add create invitation method

### DIFF
--- a/scripts/wordlist.txt
+++ b/scripts/wordlist.txt
@@ -304,3 +304,4 @@ yaml
 pre
 env
 IDP
+enum

--- a/src/dev/integration/index.md
+++ b/src/dev/integration/index.md
@@ -142,6 +142,24 @@ Arguments:
 
 > The user account is not removed. This method only removes their access to the workspace.
 
+#### Invite user to workspace
+
+::: warning API availability
+The following method is available for Python API Client versions `0.10.3` or higher, using server versions `2025.6.1` or higher.
+:::
+
+```python
+client.create_invitation(<workspace_id>, <email>, <workspace_role>)
+```
+
+Arguments:
+
+`workspace_id` (int): The workspace ID where the user will be invited.
+
+`email` (string): The email of an existing user.
+
+`workspace_role` (string): The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+
 ---
 
 ### Project collaborators methods
@@ -207,7 +225,7 @@ Arguments:
 
 `user_id` (int): ID of the user.
 
-> The user account is not removed, only the project access. 
+> The user account is not removed, only the project access.
 
 ## Further details
 

--- a/src/dev/integration/index.md
+++ b/src/dev/integration/index.md
@@ -53,6 +53,13 @@ You can create new users and manage their roles using the following methods.
 The following methods are available for Python API Client versions `0.10.0` or higher, using server versions `2025.2.0` or higher.
 :::
 
+Some of the following methods require a `workspace_role` argument. This must be provided as a member of the `WorkspaceRole` enum.
+To use the enum, import it from the `common.py` module:
+
+```python
+from mergin.common import WorkspaceRole
+```
+
 ### Create a user
 
 ```python
@@ -69,7 +76,7 @@ Arguments:
 
 `workspace_id` (int) <span title="Ignored on Community edition servers">:information_source:</span> : The workspace ID where the user will be added.
 
-`workspace_role` (string) <span title="Ignored on Community edition servers">:information_source:</span> : The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (`WorkspaceRole` enum) <span title="Ignored on Community edition servers">:information_source:</span> : The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 `username` (string, optional): If not provided, it will be automatically generated from the email address.
 
@@ -77,7 +84,9 @@ Arguments:
 
 Example:
 ```python
-client.create_user("jill@example.com", "T0p_secret", 1, "editor", notify_user=True)
+from mergin.common import WorkspaceRole
+
+client.create_user("jill@example.com", "T0p_secret", 1, WorkspaceRole.EDITOR, notify_user=True)
 ```
 
 > :information_source: `workspace_id` and `workspace_role` arguments are ignored on Community edition servers.
@@ -125,7 +134,7 @@ Arguments:
 
 `user_id` (int): ID of the user.
 
-`workspace_role` (string): New role. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (`WorkspaceRole` enum): New role. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 `reset_projects_roles` (Boolean, optional): If true, overridden project roles (explicitly shared projects access) will be reset. Default is `False`.
 
@@ -158,7 +167,7 @@ Arguments:
 
 `email` (string): The email of an existing user.
 
-`workspace_role` (string): The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (`WorkspaceRole` enum): The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 ---
 
@@ -173,6 +182,13 @@ The following methods are available for Python API Client versions `0.10.0` or h
 The caller of the following methods must be a workspace admin, owner, project owner or server administrator.
 
 The following methods accept project ids (of type `uuid`). You can find project id via <GitHubRepo id="MerginMaps/python-api-client/blob/634237890afd9f28f03953e5a01376b56f5abf5c/mergin/client.py#L572" desc="projects_list" /> and <GitHubRepo id="MerginMaps/python-api-client/blob/634237890afd9f28f03953e5a01376b56f5abf5c/mergin/client.py#L641" desc="project_info" /> methods.
+
+Some of the following methods require a `project_role` argument. This must be provided as a member of the `ProjectRole` enum.
+To use the enum, import it from the `common.py` module:
+
+```python
+from mergin.common import ProjectRole
+```
 
 #### List project collaborators
 
@@ -197,7 +213,7 @@ Arguments:
 
 `user` (string): Email or username of the user to be added to the project. 
 
-`project_role`: (string): Role of the user in the project. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
+`project_role`: (`ProjectRole` enum): Role of the user in the project. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
 
 #### Update project collaborator role
 
@@ -210,7 +226,7 @@ Arguments:
 
 `user_id` (int): ID of the user.
 
-`project_role`: (string): New role. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
+`project_role`: (`ProjectRole` enum): New role. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
 
 > The user must be first added to the project (via [Add project collaborator](./index.md#add-project-collaborator)) before calling this method, even if he/she is already a workspace member or guest.
 


### PR DESCRIPTION
Mention the ability to create an invitation from the client (https://github.com/MerginMaps/python-api-client/issues/252)

Fix argument type for workspace member methods and project collaborators methods.
The argument is not a string but the enum member.