### PR TITLE
Add default value for mergin logo in emails

### DIFF
--- a/src/server/environment/index.md
+++ b/src/server/environment/index.md
@@ -86,7 +86,7 @@ To ease the process of permission (user) management, you can set the following g
 | `MAIL_USE_TLS`🛡️       | Boolean |   `true`        | Use TLS encryption when connecting to SMTP server.  |
 | `MAIL_USE_SSL`🛡️       | Boolean |   `false`        | Whether to use SSL encryption when connecting to SMTP server.  |
 | `MAIL_BCC`              | string  |   `None`   | Email address to send copies of all sent emails. Should be system/application administrator. Mandatory in versions until 2024.4.0.  |
-| `MERGIN_LOGO_URL`       | string  | ``    | Link to logo in emails. |
+| `MERGIN_LOGO_URL`       | string  | `https://merginmaps.com/MM_logo_HORIZ_COLOR_TRANSPARENT_no_padding.png`    | Link to logo in emails. |
 
 If you have issues with sending emails, follow [troubleshooting](../troubleshoot/) page.
 


### PR DESCRIPTION
- there was missing logo in custom deployments
- Therefore, we added default value for mergin maps logo