### PR TITLE
Use string as workspace and project role

### DIFF
--- a/src/dev/integration/index.md
+++ b/src/dev/integration/index.md
@@ -54,9 +54,6 @@ You can create new users and manage their roles using the following methods.
 The following methods are available for Python API Client versions `0.10.0` or higher, using server versions `2025.2.0` or higher.
 :::
 
-Some of the following methods require a `workspace_role` argument. This must be provided as a member of the `WorkspaceRole` enum.
-To use the enum, import it from the `common.py` module:
-
 ```python
 from mergin.common import WorkspaceRole
 ```
@@ -77,7 +74,11 @@ Arguments:
 
 `workspace_id` (int) <span title="Ignored on Community edition servers">:information_source:</span> : The workspace ID where the user will be added.
 
-`workspace_role` (`WorkspaceRole` enum) <span title="Ignored on Community edition servers">:information_source:</span> : The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (string or `WorkspaceRole` enum) <span title="Ignored on Community edition servers">:information_source:</span> : The user’s role in the workspace.
+
+- String: Pass the role name directly (e.g., "guest", "reader", "editor").
+- Enum: Pass a member of the `WorkspaceRole` enum (requires importing from mergin.common)
+- [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 `username` (string, optional): If not provided, it will be automatically generated from the email address.
 
@@ -135,7 +136,7 @@ Arguments:
 
 `user_id` (int): ID of the user.
 
-`workspace_role` (`WorkspaceRole` enum): New role. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (string or `WorkspaceRole` enum): New role. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 `reset_projects_roles` (Boolean, optional): If true, overridden project roles (explicitly shared projects access) will be reset. Default is `False`.
 
@@ -168,7 +169,7 @@ Arguments:
 
 `email` (string): The email of an existing user.
 
-`workspace_role` (`WorkspaceRole` enum): The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
+`workspace_role` (string or `WorkspaceRole` enum): The user’s role in the workspace. [See the roles options](../../manage/permissions/index.md#workspace-member-roles-overview).
 
 ---
 
@@ -184,12 +185,6 @@ The caller of the following methods must be a workspace admin, owner, project ow
 
 The following methods accept project ids (of type `uuid`). You can find project id via <GitHubRepo id="MerginMaps/python-api-client/blob/634237890afd9f28f03953e5a01376b56f5abf5c/mergin/client.py#L572" desc="projects_list" /> and <GitHubRepo id="MerginMaps/python-api-client/blob/634237890afd9f28f03953e5a01376b56f5abf5c/mergin/client.py#L641" desc="project_info" /> methods.
 
-Some of the following methods require a `project_role` argument. This must be provided as a member of the `ProjectRole` enum.
-To use the enum, import it from the `common.py` module:
-
-```python
-from mergin.common import ProjectRole
-```
 
 #### List project collaborators
 
@@ -206,6 +201,7 @@ Adds a user as project collaborator. This method is good for sharing projects wi
 On Cloud, the user must be a in the workspace where the project belongs.
 
 ```python
+from mergin.common import ProjectRole
 client.add_project_collaborator(<project_id>, <user>, <project_role>)
 ```
 Arguments:
@@ -214,7 +210,11 @@ Arguments:
 
 `user` (string): Email or username of the user to be added to the project. 
 
-`project_role`: (`ProjectRole` enum): Role of the user in the project. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
+`project_role`: (string or `ProjectRole` enum): Role of the user in the project. 
+
+- String: Pass the role name directly (e.g., 'reader', 'editor', 'owner').
+- Enum: Pass a member of the `ProjectRole` enum (requires importing from mergin.common)
+- [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
 
 #### Update project collaborator role
 
@@ -227,7 +227,7 @@ Arguments:
 
 `user_id` (int): ID of the user.
 
-`project_role`: (`ProjectRole` enum): New role. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
+`project_role`: (string or `ProjectRole` enum): New role. [See the roles options](../../manage/permissions/index.md#project-permissions-overview)
 
 > The user must be first added to the project (via [Add project collaborator](./index.md#add-project-collaborator)) before calling this method, even if he/she is already a workspace member or guest.
 


### PR DESCRIPTION
Reflects https://github.com/MerginMaps/python-api-client/pull/284

The argument can be provided in both formats now (string as well as the Enum member)