### PR TITLE
add data types to extra variables

### DIFF
--- a/src/layer/variables/index.md
+++ b/src/layer/variables/index.md
@@ -15,15 +15,16 @@ Here you can find the lists of:
 
 The <QGISPluginName /> adds several variables that can be used in QGIS expressions:
 
-| Variable name               | Sample value                  | Scope   | Description |
-|-----------------------------|-------------------------------|---------|-------------
-| `@mm_full_name`          | `martin second name`                      | global  | Full name of the currently logged in user, blank if the full name is not set |
-| `@mm_username`          | `martin`                      | global  | Username of the user currently logged in to <MainPlatformNameLink /> |
-| `@mm_user_email`        | `martin@example.com` | global  | Email of the user currently logged in to <MainPlatformName />|
-| `@mm_url`               | `https://app.merginmaps.com`  | global  | URL of the <MainPlatformName /> service |
-| `@mm_project_name`      | `Tree survey`                 | project | Name of the active <MainPlatformName /> project  |
-| `@mm_project_full_name` | `martin/Tree survey`          | project | Workspace and project name joined with a forward slash |
-| `@mm_project_version`   | `42`                          | project | Current version of the active project |
+| Variable name           | Type       | Sample value   | Description |
+|-------------------------|-----------------|----------------|-------------|
+| `@mm_full_name`         | string| `Joe Schmoe`  | Full name of the currently logged in user, blank if the full name is not set  |
+| `@mm_username`          | string | `joe-schmoe`  | Username of the user currently logged in to <MainPlatformNameLink />  |
+| `@mm_user_email`        | string | `joe.schmoe@mail.com`  | Email of the user currently logged in to <MainPlatformName /> |
+| `@mm_url`               | string | `https://app.merginmaps.com`  | URL of the <MainPlatformName /> service  |
+| `@mm_project_name`      | string | `My project` | Name of the active <MainPlatformName /> project  |
+| `@mm_project_full_name` | string | `my-team/My project` | Workspace and project name joined with a forward slash |
+| `@mm_project_version`   | integer      | `9` | Current version of the active project |
+
 
 A common use case is to use `@mm_username` or `@mm_user_email` as the [default value](../default-values/) for one of the fields in a survey layer to automatically track who has added (and/or modified) a particular record.
 
@@ -39,36 +40,31 @@ With <MobileAppName />, it is possible to access GPS information using extra pos
 
 Extra position variables can be used as [default values in feature forms](../default-values/).
 
-Following variables are supported:
- - `@position_coordinate` - A point with the coordinates in WGS84.
- - `@position_latitude` - Latitude
- - `@position_longitude` - Longitude
- - `@position_elevation` - Orthometric or normal height
- - `@position_elevation_ellipsoid` - Ellipsoidal height
- - `@position_geoid_separation` - Geoid or quasi-geoid height (undulation)
- - `@position_direction` - The bearing measured in degrees clockwise from true north to the direction of travel.
- - `@position_ground_speed` - The ground speed, in meters/sec.
- - `@position_vertical_speed` - The vertical speed, in meters/sec.
- - `@position_magnetic_variation` - The angle between the horizontal component of the magnetic field and true north, in degrees. Also known as magnetic declination. A positive value indicates a clockwise direction from true north and a negative value indicates a counter-clockwise direction.
- - `@position_horizontal_accuracy` - The accuracy of the provided latitude-longitude value, in meters.
- - `@position_vertical_accuracy` - The accuracy of the provided altitude value, in meters.
- - `@position_from_gps` - True, if recorded/edited feature's geometry corresponds with current user's position (Position marker has the same location as the crosshairs marker).
- - `@position_satellites_visible` - Number of visible satellites.
- - `@position_satellites_used` - Number of satellites used to calculate the position.
- - `@position_gps_fix` - GPS fix, e.g. "RTK float"
- - `@position_gps_antenna_height` - Antenna height as defined in [GPS settings](../../field/mobile-app-ui/#gps-settings)
- - `@position_provider_type` - GPS device type.
-   - for internal GPS, returns "internal"
-   - for external GPS, returns "external"
- - `@position_provider_name` - GPS device name.
-   - for internal GPS, returns "Internal"
-   - for external GPS, returns the name of the external device
- - `@position_provider_address` - GPS device address.
-   - for internal GPS, returns "<NoSpellcheck id="devicegps" />"
-   - for external GPS, returns the MAC address
- - `@position_hdop` - Horizontal dilution of precision (HDOP)
- - `@position_vdop` - Vertical dilution of precision (VDOP)
- - `@position_pdop` - Position (3D) dilution of precision (PDOP)
+| Variable name           | Type       | Description |
+|-------------------------|-----------------|-------------|
+| `@position_coordinate` | geometry | A point with the coordinates in WGS84 |
+| `@position_latitude` | decimal | Latitude |
+| `@position_longitude` | decimal | Longitude |
+| `@position_elevation` | decimal | Orthometric or normal height |
+| `@position_elevation_ellipsoid`  | decimal | Ellipsoidal height |
+| `@position_geoid_separation`  | decimal | Geoid or quasi-geoid height (undulation) |
+| `@position_direction`  | integer | The bearing measured in degrees clockwise from true north to the direction of travel |
+| `@position_ground_speed`  | decimal | The ground speed, in meters/sec |
+| `@position_vertical_speed`  | decimal | The vertical speed, in meters/sec |
+| `@position_magnetic_variation`  | decimal | The angle between the horizontal component of the magnetic field and true north, in degrees. Also known as magnetic declination. A positive value indicates a clockwise direction from true north and a negative value indicates a counter-clockwise direction. |
+| `@position_horizontal_accuracy`  | decimal | The accuracy of the provided latitude-longitude value, in meters |
+| `@position_vertical_accuracy`  | decimal | The accuracy of the provided altitude value, in meters |
+| `@position_from_gps`  | Boolean | *True* if recorded/edited feature's geometry corresponds with current user's position (position marker has the same location as the crosshairs marker) |
+| `@position_satellites_visible`  | integer | Number of visible satellites |
+| `@position_satellites_used`  | integer | Number of satellites used to calculate the position |
+| `@position_gps_fix`  | string | GPS fix, e.g. "RTK float" |
+| `@position_gps_antenna_height`  | decimal | Antenna height as defined in [GPS settings](../../field/mobile-app-ui/#gps-settings) |
+| `@position_provider_type`  | string | GPS device type (for internal GPS, returns "internal", for external GPS, returns "external") |
+| `@position_provider_name`  | string | GPS device name (for internal GPS, returns "Internal", for external GPS, returns the name of the external device) |
+| `@position_provider_address`  | string | GPS device address (for internal GPS, returns "<NoSpellcheck id="devicegps" />", for external GPS, returns the MAC address) |
+| `@position_hdop`  | decimal | Horizontal dilution of precision (HDOP) |
+| `@position_vdop`  | decimal | Vertical dilution of precision (VDOP) |
+| `@position_pdop`  | decimal | Position (3D) dilution of precision (PDOP) |
 
 :::tip
 **Dilution of precision** (DOP) is a useful value that reflects the confidence level of achieved position precision. In addition to the horizontal and vertical accuracy, the appropriate DOP value (horizontal, vertical, or 3D) can be used to assess the overall quality of your survey accuracy.

--- a/src/layer/variables/index.md
+++ b/src/layer/variables/index.md
@@ -17,13 +17,13 @@ The <QGISPluginName /> adds several variables that can be used in QGIS expressio
 
 | Variable name           | Type       | Sample value   | Description |
 |-------------------------|-----------------|----------------|-------------|
-| `@mm_full_name`         | string| `Joe Schmoe`  | Full name of the currently logged in user, blank if the full name is not set  |
-| `@mm_username`          | string | `joe-schmoe`  | Username of the user currently logged in to <MainPlatformNameLink />  |
-| `@mm_user_email`        | string | `joe.schmoe@mail.com`  | Email of the user currently logged in to <MainPlatformName /> |
-| `@mm_url`               | string | `https://app.merginmaps.com`  | URL of the <MainPlatformName /> service  |
-| `@mm_project_name`      | string | `My project` | Name of the active <MainPlatformName /> project  |
-| `@mm_project_full_name` | string | `my-team/My project` | Workspace and project name joined with a forward slash |
-| `@mm_project_version`   | integer      | `9` | Current version of the active project |
+| `@mm_full_name`         | Text (string) | `Joe Schmoe`  | Full name of the currently logged in user, blank if the full name is not set  |
+| `@mm_username`          | Text (string) | `joe-schmoe`  | Username of the user currently logged in to <MainPlatformNameLink />  |
+| `@mm_user_email`        | Text (string) | `joe.schmoe@mail.com`  | Email of the user currently logged in to <MainPlatformName /> |
+| `@mm_url`               | Text (string) | `https://app.merginmaps.com`  | URL of the <MainPlatformName /> service  |
+| `@mm_project_name`      | Text (string) | `My project` | Name of the active <MainPlatformName /> project  |
+| `@mm_project_full_name` | Text (string) | `my-team/My project` | Workspace and project name joined with a forward slash |
+| `@mm_project_version`   | Number (integer) | `9` | Current version of the active project |
 
 
 A common use case is to use `@mm_username` or `@mm_user_email` as the [default value](../default-values/) for one of the fields in a survey layer to automatically track who has added (and/or modified) a particular record.
@@ -42,29 +42,29 @@ Extra position variables can be used as [default values in feature forms](../def
 
 | Variable name           | Type       | Description |
 |-------------------------|-----------------|-------------|
-| `@position_coordinate` | geometry | A point with the coordinates in WGS84 |
-| `@position_latitude` | decimal | Latitude |
-| `@position_longitude` | decimal | Longitude |
-| `@position_elevation` | decimal | Orthometric or normal height |
-| `@position_elevation_ellipsoid`  | decimal | Ellipsoidal height |
-| `@position_geoid_separation`  | decimal | Geoid or quasi-geoid height (undulation) |
-| `@position_direction`  | integer | The bearing measured in degrees clockwise from true north to the direction of travel |
-| `@position_ground_speed`  | decimal | The ground speed, in meters/sec |
-| `@position_vertical_speed`  | decimal | The vertical speed, in meters/sec |
-| `@position_magnetic_variation`  | decimal | The angle between the horizontal component of the magnetic field and true north, in degrees. Also known as magnetic declination. A positive value indicates a clockwise direction from true north and a negative value indicates a counter-clockwise direction. |
-| `@position_horizontal_accuracy`  | decimal | The accuracy of the provided latitude-longitude value, in meters |
-| `@position_vertical_accuracy`  | decimal | The accuracy of the provided altitude value, in meters |
+| `@position_coordinate` | Geometry | A point with the coordinates in WGS84 |
+| `@position_latitude` | Number (decimal) | Latitude |
+| `@position_longitude` | Number (decimal) | Longitude |
+| `@position_elevation` | Number (decimal) | Orthometric or normal height |
+| `@position_elevation_ellipsoid`  | Number (decimal) | Ellipsoidal height |
+| `@position_geoid_separation`  | Number (decimal) | Geoid or quasi-geoid height (undulation) |
+| `@position_direction`  | Number (integer) | The bearing measured in degrees clockwise from true north to the direction of travel |
+| `@position_ground_speed`  | Number (decimal) | The ground speed, in meters/sec |
+| `@position_vertical_speed`  | Number (decimal) | The vertical speed, in meters/sec |
+| `@position_magnetic_variation`  | Number (decimal) | The angle between the horizontal component of the magnetic field and true north, in degrees. Also known as magnetic declination. A positive value indicates a clockwise direction from true north and a negative value indicates a counter-clockwise direction. |
+| `@position_horizontal_accuracy`  | Number (decimal) | The accuracy of the provided latitude-longitude value, in meters |
+| `@position_vertical_accuracy`  | Number (decimal) | The accuracy of the provided altitude value, in meters |
 | `@position_from_gps`  | Boolean | *True* if recorded/edited feature's geometry corresponds with current user's position (position marker has the same location as the crosshairs marker) |
-| `@position_satellites_visible`  | integer | Number of visible satellites |
-| `@position_satellites_used`  | integer | Number of satellites used to calculate the position |
-| `@position_gps_fix`  | string | GPS fix, e.g. "RTK float" |
-| `@position_gps_antenna_height`  | decimal | Antenna height as defined in [GPS settings](../../field/mobile-app-ui/#gps-settings) |
-| `@position_provider_type`  | string | GPS device type (for internal GPS, returns "internal", for external GPS, returns "external") |
-| `@position_provider_name`  | string | GPS device name (for internal GPS, returns "Internal", for external GPS, returns the name of the external device) |
-| `@position_provider_address`  | string | GPS device address (for internal GPS, returns "<NoSpellcheck id="devicegps" />", for external GPS, returns the MAC address) |
-| `@position_hdop`  | decimal | Horizontal dilution of precision (HDOP) |
-| `@position_vdop`  | decimal | Vertical dilution of precision (VDOP) |
-| `@position_pdop`  | decimal | Position (3D) dilution of precision (PDOP) |
+| `@position_satellites_visible`  | Number (integer) | Number of visible satellites |
+| `@position_satellites_used`  | Number (integer) | Number of satellites used to calculate the position |
+| `@position_gps_fix`  | Text (string) | GPS fix, e.g. "RTK float" |
+| `@position_gps_antenna_height`  | Number (decimal) | Antenna height as defined in [GPS settings](../../field/mobile-app-ui/#gps-settings) |
+| `@position_provider_type`  | Text (string) | GPS device type (for internal GPS, returns "internal", for external GPS, returns "external") |
+| `@position_provider_name`  | Text (string) | GPS device name (for internal GPS, returns "Internal", for external GPS, returns the name of the external device) |
+| `@position_provider_address`  | Text (string) | GPS device address (for internal GPS, returns "<NoSpellcheck id="devicegps" />", for external GPS, returns the MAC address) |
+| `@position_hdop`  | Number (decimal) | Horizontal dilution of precision (HDOP) |
+| `@position_vdop`  | Number (decimal) | Vertical dilution of precision (VDOP) |
+| `@position_pdop`  | Number (decimal) | Position (3D) dilution of precision (PDOP) |
 
 :::tip
 **Dilution of precision** (DOP) is a useful value that reflects the confidence level of achieved position precision. In addition to the horizontal and vertical accuracy, the appropriate DOP value (horizontal, vertical, or 3D) can be used to assess the overall quality of your survey accuracy.


### PR DESCRIPTION
fix #749 
- data types added to [Variables](https://merginmaps.com/docs/layer/variables/) 
- position variables added to a table (instead of a list) to be consistent across the docs 