### PR TITLE
sidebar nested pages

### DIFF
--- a/src/.vitepress/sidebar/en.js
+++ b/src/.vitepress/sidebar/en.js
@@ -62,8 +62,9 @@ export default {
       collapsed: true,
       items: [
         { text: 'Overview', link: '/layer/overview/' },
-        { text: 'Widgets', link: '/layer/form-widgets/',
+        { text: 'Widgets',
         items: [
+           { text: 'Form Widgets Gallery', link: '/layer/form-widgets/' },
            { text: 'Text', link: '/layer/text/' },
            { text: 'Date and Time', link: '/layer/date-time/' },
            { text: 'Relations', link: '/layer/relations/' },
@@ -74,22 +75,25 @@ export default {
            { text: 'Photos', link: '/layer/photos/' },
            { text: 'Informational Widgets', link: '/layer/info-widgets/' },
         ] },
-        { text: 'Default Values', link: '/layer/default-values/',
+        { text: 'Default Values',
         collapsed: true,
         items: [
+           { text: 'Default Values Setup', link: '/layer/default-values/' },
            { text: 'Geotagging', link: '/layer/exif/' },
            { text: 'Variables', link: '/layer/variables/' }
         ] },
         { text: 'Constraints', link: '/layer/constraints/' },        
-        { text: 'Layout', link: '/layer/form-layout/',
+        { text: 'Layout',
         collapsed: true,
         items: [
+           { text: 'Attributes Form Layout', link: '/layer/form-layout/' },
            { text: 'Tabs and Groups', link: '/layer/tabs-and-groups/' },
            { text: 'Conditional Visibility', link: '/layer/conditional-visibility/' },
         ] },
-        { text: 'Use Cases', link: '/layer/use-cases/', 
+        { text: 'Use Cases', 
         collapsed: true,
         items: [
+           { text: 'Use Cases Overview', link: '/layer/use-cases/' },
 	   { text: 'How to Open a File', link: '/layer/open-file/' },
 	   { text: 'How to Use Hyperlinks', link: '/layer/external-link/' },
            { text: 'How to Open a Link to a Navigation App', link: '/layer/link-to-navigation/' },
@@ -159,9 +163,10 @@ export default {
       items: [
         { text: 'Licensing', link: '/misc/licensing/' },
         { text: 'Get Involved', link: '/misc/get-involved/' },
-        { text: 'Troubleshoot', link: '/misc/troubleshoot/',
+        { text: 'Troubleshoot',
         collapsed:true,
         items: [
+           { text: 'Support and Troubleshooting', link: '/misc/troubleshoot/' },
            { text: 'Project fails to sync', link: '/misc/troubleshoot/not_syncing/' },
         ] },
         { text: 'Write Documentation', link: '/misc/write-docs/' }

--- a/src/.vitepress/sidebar/en.js
+++ b/src/.vitepress/sidebar/en.js
@@ -64,7 +64,7 @@ export default {
         { text: 'Overview', link: '/layer/overview/' },
         { text: 'Widgets',
         items: [
-           { text: 'Form Widgets Gallery', link: '/layer/form-widgets/' },
+           { text: 'Available Widgets', link: '/layer/form-widgets/' },
            { text: 'Text', link: '/layer/text/' },
            { text: 'Date and Time', link: '/layer/date-time/' },
            { text: 'Relations', link: '/layer/relations/' },
@@ -86,7 +86,7 @@ export default {
         { text: 'Layout',
         collapsed: true,
         items: [
-           { text: 'Attributes Form Layout', link: '/layer/form-layout/' },
+           { text: 'Form Layout', link: '/layer/form-layout/' },
            { text: 'Tabs and Groups', link: '/layer/tabs-and-groups/' },
            { text: 'Conditional Visibility', link: '/layer/conditional-visibility/' },
         ] },

--- a/src/index.md
+++ b/src/index.md
@@ -70,7 +70,8 @@ The ecosystem consist of various components:
 
 ## Configure Forms
 - [Overview](./layer/overview/)
-- [Widgets](./layer/form-widgets/)
+- Widgets
+   - [Available Widgets](./layer/form-widgets/)
    - [Text](./layer/text/)
    - [Date and time](./layer/date-time/)
    - [Relations](./layer/relations/)
@@ -80,14 +81,17 @@ The ecosystem consist of various components:
    - [Selecting Single or Multiple Values ](./layer/value-select/)
    - [Photos](./layer/photos/)
    - [Informational Widgets](./layer/info-widgets/)
-- [Default Values](./layer/default-values/)
+- Default Values
+   - [Default Values Setup](./layer/default-values/)
    - [Geotagging](./layer/exif/)
    - [Variables](./layer/variables/)
 - [Constraints](./layer/constraints/)
-- [Layout](./layer/form-layout/)
+- Layout
+   - [Form Layout](./layer/form-layout/)
    - [Tabs and Groups](./layer/tabs-and-groups/)
    - [Conditional Visibility](./layer/conditional-visibility/)
-- [Use Cases](./layer/use-cases/)
+- Use Cases
+   - [Use Cases Overview](./layer/use-cases/)
    - [How to Open a File ](./layer/open-file/)
    - [How to Use Hyperlinks](./layer/external-link/)
    - [How to Open a Link to a Navigation App](./layer/link-to-navigation/)

--- a/src/layer/default-values/index.md
+++ b/src/layer/default-values/index.md
@@ -2,7 +2,7 @@
 description: Default values can be used to automatically fill in the fields in the form using values, variables or expressions.
 ---
 
-# Default values
+# Default Values
 Default values can be used to automatically record, e.g. the name of the surveyor, date and time of the survey, latitude and longitude of a feature or to have frequently used values filled in advance (see <QGISHelp ver="latest" link="user_manual/working_with_vector/vector_properties.html#default-values" text="QGIS documentation" />). 
 
 Fields with default values can be hidden from the attributes form if they are used to store data that are not expected to be modified manually.

--- a/src/layer/form-layout/index.md
+++ b/src/layer/form-layout/index.md
@@ -2,7 +2,7 @@
 description: Use QGIS drag and drop designer, conditional visibility, and widgets to create attributes forms tailored to your Mergin Maps project needs.
 ---
 
-# Attributes Form Layout
+# Form Layout
 [[toc]]
 
 Collecting and editing data in the field can be more efficient with forms that are easy to navigate. QGIS offers a lot of options for improving the layout of your forms, such as using [tabs and groups](../tabs-and-groups/) to keep related fields together, displaying or hiding a group of fields based on [conditional visibility](../conditional-visibility/), or displaying tips and instructions in the forms using the [Text or HTML widget](../info-widgets/). The starting point for creating a form is [QGIS Drag and Drop Designer](#qgis-drag-and-drop-designer).

--- a/src/layer/form-widgets/index.md
+++ b/src/layer/form-widgets/index.md
@@ -2,7 +2,7 @@
 description: Our Widget Gallery provides an overview of QGIS form widgets supported by the Mergin Maps mobile app. Find the best widget for your survey form!
 ---
 
-# Form Widgets Gallery
+# Available Widgets
 
 Form widgets define the way you can enter values in the form, both in QGIS and in the <MobileAppNameShort />. The configuration of form widgets in your <MainPlatformNameLink /> project is done in QGIS.
 

--- a/src/misc/troubleshoot/index.md
+++ b/src/misc/troubleshoot/index.md
@@ -2,7 +2,7 @@
 description: Find troubleshooting tips, resources, and support information to help resolve issues with Mergin Maps.
 ---
 
-# Troubleshoot
+# Support and Troubleshooting
 [[toc]]
 
 ## Troubleshooting tips


### PR DESCRIPTION
fix #761 
Nested pages in the sidebar now have un-clickable "subsection title" instead of a docs page. Instead of using "overview" I changed the titles a bit to better represent the content.
